### PR TITLE
Fix the recipe list display.

### DIFF
--- a/pages/recipes/index.js
+++ b/pages/recipes/index.js
@@ -23,15 +23,7 @@ class RecipesPage extends React.Component {
             fetch(constants.get_recipe_api_url + listdata.recipes[i])
                 .then(r => r.json())
                 .then(recipedata => {
-                      // data returned is of form {"<recipe name>": {<recipe>}}, just return recipe
-                      // Cannot use i or listdata in here, iterate the keys instead
-                      for (var key in recipedata) {
-                          if (recipedata.hasOwnProperty(key)) {
-                              this.setState(
-                                  { recipes: this.state.recipes.concat(recipedata[key]) }
-                              );
-                          }
-                     }
+                      this.setState({ recipes: this.state.recipes.concat(recipedata[listdata.recipes[i]]) });
                 });
         }
       })


### PR DESCRIPTION
Getting to the recipe object the hard way was a side effect of sloppy
example data and mine own poor understanding of what a javascript
promise actually closes over. As a side-effect, when running under json
recipe, the recipe list ended up with a ghost recipe from the extra "id"
attribute. Bust the ghost.

Resolves #17 