### PR TITLE
UI refinements

### DIFF
--- a/components/ListView/ComponentDetailsView.js
+++ b/components/ListView/ComponentDetailsView.js
@@ -94,13 +94,18 @@ class ComponentDetailsView extends React.Component {
       <div className="cmpsr-compon-details">
         { this.state.parents.length > 0 &&
         <ol className="breadcrumb">
+          <li><a href="#" onClick={(e) => this.props.handleComponentDetails(e, "")}>Back to {this.props.parent}</a></li>
           {this.state.parents.map((parent,i) =>
-            <li key={i} className={i}><a href="#" onClick={(e) => this.props.handleComponentDetails(e, parent, this.state.parents[i-1])}>{parent.name}</a></li>
+          <li key={i}><a href="#" onClick={(e) => this.props.handleComponentDetails(e, parent, this.state.parents[i-1])}>{parent.name}</a></li>
           )}
           <li></li>
         </ol>
+        ||
+        <ol className="breadcrumb">
+          <li><a href="#" onClick={(e) => this.props.handleComponentDetails(e, "")}>Back to {this.props.parent}</a></li>
+        </ol>
         }
-    		<h2>
+    		<h3>
     			<span data-item="name"><ComponentTypeIcons componentType={ component.ui_type } /> {component.name} </span>
     			<div className="pull-right">
     				<ul className="list-inline">
@@ -126,7 +131,7 @@ class ComponentDetailsView extends React.Component {
     					</li>
     				</ul>
     			</div>
-    		</h2>
+    		</h3>
 
         { this.props.status == "available" &&
     		<div className="blank-slate-pf">

--- a/components/ListView/RecipeContents.js
+++ b/components/ListView/RecipeContents.js
@@ -13,7 +13,7 @@ class RecipeContents extends React.Component {
 
 
     return (
-      <div className="panel-group row" id="cmpsr-recipe-contents">
+      <div className="panel-group" id="cmpsr-recipe-contents">
         <div className="panel panel-default">
           <div className="panel-heading">
             <h4 className="panel-title">

--- a/components/Toolbar/Toolbar.js
+++ b/components/Toolbar/Toolbar.js
@@ -32,19 +32,20 @@ class Toolbar extends React.Component {
               </div>
               <button className="btn btn-link" type="button"><span className="fa fa-sort-alpha-asc"></span></button>
             </div>
-            <div className="form-group">
-              <button className="btn btn-default" id="cmpsr-btn-crt-compos" data-toggle="modal" data-target="#cmpsr-modal-crt-compos" type="button">Create Composition</button>
-              <div className="dropdown btn-group  dropdown-kebab-pf">
-                <button className="btn btn-link dropdown-toggle" type="button" id="dropdownKebab" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><span className="fa fa-ellipsis-v"></span></button>
-                <ul className="dropdown-menu " aria-labelledby="dropdownKebab">
-                  <li><a href="#">Export Recipe</a></li>
-                  <li role="separator" className="divider"></li>
-                  <li><a href="#">Update Selected Components</a></li>
-                  <li><a href="#">Remove Selected Components</a></li>
-                </ul>
-              </div>
-            </div>
+
             <div className="toolbar-pf-action-right">
+              <div className="form-group">
+                <button className="btn btn-default" id="cmpsr-btn-crt-compos" data-toggle="modal" data-target="#cmpsr-modal-crt-compos" type="button">Create Composition</button>
+                <div className="dropdown btn-group  dropdown-kebab-pf">
+                  <button className="btn btn-link dropdown-toggle" type="button" id="dropdownKebab" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><span className="fa fa-ellipsis-v"></span></button>
+                  <ul className="dropdown-menu " aria-labelledby="dropdownKebab">
+                    <li><a href="#">Export Recipe</a></li>
+                    <li role="separator" className="divider"></li>
+                    <li><a href="#">Update Selected Components</a></li>
+                    <li><a href="#">Remove Selected Components</a></li>
+                  </ul>
+                </div>
+              </div>
               <div className="form-group toolbar-pf-find">
                 <button className="btn btn-link btn-find" type="button"><span className="fa fa-search"></span></button>
                 <div className="find-pf-dropdown-container"><input type="text" className="form-control" id="find" placeholder="Find By Keyword..." />
@@ -55,11 +56,6 @@ class Toolbar extends React.Component {
                     <button className="btn btn-link btn-find-close" type="button"><span className="pficon pficon-close"></span></button>
                   </div>
                 </div>
-              </div>
-              <div className="form-group toolbar-pf-view-selector hidden">
-                <button className="btn btn-link" title="Table View"><i className="fa fa-th"></i></button>
-                <button className="btn btn-link hidden" title="Tree View"><i className="pficon pficon-topology"></i></button>
-                <button className="btn btn-link active" title="List View"><i className="fa fa-th-list"></i></button>
               </div>
             </div>
           </form>

--- a/pages/recipe/index.js
+++ b/pages/recipe/index.js
@@ -110,17 +110,17 @@ class RecipePage extends React.Component {
                       </div>
                       <button className="btn btn-link" type="button"><span className="fa fa-sort-alpha-asc"></span></button>
                     </div>
-                    <div className="form-group">
-                      <Link to={"/edit/" + this.props.route.params.recipe } className="btn btn-default">Edit Recipe</Link>
-                      <button className="btn btn-default" id="cmpsr-btn-crt-compos" data-toggle="modal" data-target="#cmpsr-modal-crt-compos" type="button">Create Composition</button>
-                      <div className="dropdown btn-group  dropdown-kebab-pf">
-                        <button className="btn btn-link dropdown-toggle" type="button" id="dropdownKebab" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><span className="fa fa-ellipsis-v"></span></button>
-                        <ul className="dropdown-menu " aria-labelledby="dropdownKebab">
-                          <li><a href="#">Export Recipe</a></li>
-                        </ul>
-                      </div>
-                    </div>
                     <div className="toolbar-pf-action-right">
+                      <div className="form-group">
+                        <Link to={"/edit/" + this.props.route.params.recipe } className="btn btn-default">Edit Recipe</Link>
+                        <button className="btn btn-default" id="cmpsr-btn-crt-compos" data-toggle="modal" data-target="#cmpsr-modal-crt-compos" type="button">Create Composition</button>
+                        <div className="dropdown btn-group  dropdown-kebab-pf">
+                          <button className="btn btn-link dropdown-toggle" type="button" id="dropdownKebab" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><span className="fa fa-ellipsis-v"></span></button>
+                          <ul className="dropdown-menu " aria-labelledby="dropdownKebab">
+                            <li><a href="#">Export Recipe</a></li>
+                          </ul>
+                        </div>
+                      </div>
                       <div className="form-group toolbar-pf-find">
                         <button className="btn btn-link btn-find" type="button"><span className="fa fa-search"></span></button>
                         <div className="find-pf-dropdown-container"><input type="text" className="form-control" id="find" placeholder="Find By Keyword..." />
@@ -131,11 +131,6 @@ class RecipePage extends React.Component {
                             <button className="btn btn-link btn-find-close" type="button"><span className="pficon pficon-close"></span></button>
                           </div>
                         </div>
-                      </div>
-                      <div className="form-group toolbar-pf-view-selector">
-                        <button className="btn btn-link" title="Table View"><i className="fa fa-th"></i></button>
-                        <button className="btn btn-link " title="Tree View"><i className="pficon pficon-topology"></i></button>
-                        <button className="btn btn-link active" title="List View"><i className="fa fa-th-list"></i></button>
                       </div>
                     </div>
                   </form>
@@ -167,6 +162,7 @@ class RecipePage extends React.Component {
             ||
             <div className="col-sm-12" id="cmpsr-recipe-details">
               <ComponentDetailsView
+                parent={ this.props.route.params.recipe }
                 component={ this.state.selectedComponent }
                 componentParent={ this.state.selectedComponentParent }
                 status={ this.state.selectedComponentStatus }

--- a/pages/recipes/index.js
+++ b/pages/recipes/index.js
@@ -66,20 +66,21 @@ class RecipesPage extends React.Component {
                 </div>
                 <button className="btn btn-link" type="button"><span className="fa fa-sort-alpha-asc"></span></button>
               </div>
-              <div className="form-group">
-                <button className="btn btn-default" type="button" data-toggle="modal" data-target="#cmpsr-modal-crt-recipe">Create Recipe</button>
-                <div className="dropdown btn-group  dropdown-kebab-pf">
-                  <button className="btn btn-link dropdown-toggle" type="button" id="dropdownKebab" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><span className="fa fa-ellipsis-v"></span></button>
-                  <ul className="dropdown-menu " aria-labelledby="dropdownKebab">
-                    <li><a href="#">Import Recipe</a></li>
-                    <li role="separator" className="divider"></li>
-                    <li><a href="#">Create Compositions</a></li>
-                    <li><a href="#">Export Selected Recipes</a></li>
-                    <li><a href="#">Delete Selected Recipes</a></li>
-                  </ul>
-                </div>
-              </div>
+
               <div className="toolbar-pf-action-right">
+                <div className="form-group">
+                  <button className="btn btn-default" type="button" data-toggle="modal" data-target="#cmpsr-modal-crt-recipe">Create Recipe</button>
+                  <div className="dropdown btn-group  dropdown-kebab-pf">
+                    <button className="btn btn-link dropdown-toggle" type="button" id="dropdownKebab" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><span className="fa fa-ellipsis-v"></span></button>
+                    <ul className="dropdown-menu " aria-labelledby="dropdownKebab">
+                      <li><a href="#">Import Recipe</a></li>
+                      <li role="separator" className="divider"></li>
+                      <li><a href="#">Create Compositions</a></li>
+                      <li><a href="#">Export Selected Recipes</a></li>
+                      <li><a href="#">Delete Selected Recipes</a></li>
+                    </ul>
+                  </div>
+                </div>
                 <div className="form-group toolbar-pf-find">
                   <button className="btn btn-link btn-find" type="button"><span className="fa fa-search"></span></button>
                   <div className="find-pf-dropdown-container"><input type="text" className="form-control" id="find" placeholder="Find By Keyword..." />
@@ -90,11 +91,6 @@ class RecipesPage extends React.Component {
                       <button className="btn btn-link btn-find-close" type="button"><span className="pficon pficon-close"></span></button>
                     </div>
                   </div>
-                </div>
-                <div className="form-group toolbar-pf-view-selector">
-                  <button className="btn btn-link" title="Table View"><i className="fa fa-th"></i></button>
-                  <button className="btn btn-link " title="Tree View"><i className="pficon pficon-topology"></i></button>
-                  <button className="btn btn-link active" title="List View"><i className="fa fa-th-list"></i></button>
                 </div>
               </div>
             </form>

--- a/public/custom.css
+++ b/public/custom.css
@@ -168,6 +168,13 @@
 
 
 /* Recipe Contents Accordion */
+
+#cmpsr-recipe-contents {
+    margin: 20px 0;
+}
+#cmpsr-recipe-list-edit #cmpsr-recipe-contents {
+  margin: -1px -21px;
+}
 .panel-body .list-view-pf-view {
   margin-top: 0;
   margin-bottom: 0;
@@ -190,4 +197,7 @@
 /*Component details*/
 #cmpsr-recipe-details-edit {
   border-top: 1px solid #d1d1d1;
+}
+#cmpsr-recipe-details {
+  padding: 10px 35px;
 }


### PR DESCRIPTION
Includes UI refinements listed here: https://trello.com/c/rs56Eua4/136-ui-recipe-components-2

- The breadcrumb includes a node at the beginning: "Back to {name of recipe}"
- CSS refinements on the Recipe page (margin around the list, margin around the component details, removed double-border above component details, better visual hierarchy between page headers when viewing component details)
- include tooltips for icons and component names where truncated
- updates to toolbar to move Recipe actions to far right and remove the view toggle (and include toolbar on other tabs, minus the filter/find options where not applicable)