### PR TITLE
get metadata and dependencies for components

### DIFF
--- a/core/constants.js
+++ b/core/constants.js
@@ -18,6 +18,8 @@ const constants = {
   get_compose_types: composer_api_host + "/api/v0/compose/types",
   post_recipes_new: composer_api_host + "/api/v0/recipes/new",
 
+
+  // common functions
   setComponentType: function(data, inRecipe) {
     // get the list of modules in recipe, set their type to modules
     // get the list of packages, set their type to rpm
@@ -38,8 +40,36 @@ const constants = {
       });
     }
     return modules.concat(rpms);
+  },
+  getMetadata: function(componentName) {
+    let p = new Promise((resolve, reject) => {
+        fetch(constants.get_module_info + componentName)
+        .then(r => r.json())
+        .then(function(data){
+          resolve(data);
+        })
+        .catch(e => {
+            console.log("Failed to get module info: " + e);
+        });
+    });
+    return p;
+  },
+  getDependencies: function(componentName) {
+    let p = new Promise((resolve, reject) => {
+        fetch(constants.get_dependencies_list + componentName)
+        .then(r => r.json())
+        .then(function(data){
+          resolve(data);
+        })
+        .catch(e => {
+            console.log("Failed to get module info: " + e);
+        });
+    });
+    return p;
   }
 
 };
+
+
 
 export default constants;


### PR DESCRIPTION
There is a lot of duplication in this code, and it needs to be refactored.

The following updates are included:

- metadata is retrieved for 
	- recipe components 
	- recipe dependencies
	- selected component (i.e. by clicking on component name listed under available components on left, selected component on right, or a dependency)
	- list of dependencies that display for a selected component
- component details refreshes (specifically the list of dependencies) when clicking a component name within the component details view

Updates not included:

- display component metadata in the popover that displays when clicking a component listed on the left
- a dependency list item does not display information about it's dependencies