### PR TITLE
Fix bugs, make code smart to work with Fedora 29 and clean up useless code.

### DIFF
--- a/test/end-to-end/pages/createBlueprint.js
+++ b/test/end-to-end/pages/createBlueprint.js
@@ -81,14 +81,14 @@ module.exports = class CreateBlueprintPage extends BlueprintPage {
 
       // wait for the search results to appear
       browser
-        .waitForVisible('.list-pf-content.list-pf-content-flex');
+        .waitForVisible(editPage.availableComponentList);
 
       // find the package in the list of filtered results
-      $$('.list-pf-content.list-pf-content-flex').some((item) => {
-        const title = item.$('.list-pf-title').getText();
+      $$(editPage.availableComponentList).some((item) => {
+        const title = item.$(editPage.availableComponentName).getText();
         if (title === pkg.name) {
           // clicks on the + button
-          item.$('.btn-link').click();
+          item.$(editPage.availableComponentPlusButton).click();
         }
         return title === pkg.name;
       });

--- a/test/end-to-end/pages/editBlueprint.js
+++ b/test/end-to-end/pages/editBlueprint.js
@@ -1,6 +1,5 @@
 // Edit Blueprint page object
 const MainPage = require('./main');
-const config = require('../wdio.conf.js');
 
 module.exports = class EditBlueprintPage extends MainPage {
   constructor(blueprintName) {
@@ -16,9 +15,6 @@ module.exports = class EditBlueprintPage extends MainPage {
     // Title bar root element
     this.titleBarRootElement = 'div[class="cmpsr-title"]';
 
-    // Blueprint Components and Component Details
-    this.bodyMainRootElement = 'div[class="cmpsr-panel__body cmpsr-panel__body--main"]';
-
     // Blueprint inputs root element
     this.blueprintInputRootElement = '.cmpsr-panel__body--sidebar';
 
@@ -27,9 +23,6 @@ module.exports = class EditBlueprintPage extends MainPage {
     // ---- Page element selector ---- //
     // Component number
     this.componentNumber = '.cmpsr-blueprint__inputs__pagination span:nth-of-type(2)';
-    // Edit Blueprint label
-    this.varEditBlueprint = 'Edit Blueprint';
-    this.labelEditBlueprint = `${this.navBarRootElement} li strong`;
 
     // Back to Bluprints link
     this.linkBackToBlueprints = `${this.navBarRootElement} li a[href="#/blueprints"]`;
@@ -53,7 +46,6 @@ module.exports = class EditBlueprintPage extends MainPage {
 
     // Pending Change link
     this.linkPendingChange = `${this.editActionBarRootElement} > ul > li > a > span`;
-    this.labelLinkPendingChange = 'Pending Changes';
 
     // Commit button
     this.btnCommit = `${this.editActionBarRootElement} ul li button[class="btn btn-primary"]`;
@@ -67,16 +59,9 @@ module.exports = class EditBlueprintPage extends MainPage {
     // Discard button (disabled)
     this.btnDisabledDiscard = `${this.editActionBarRootElement} ul li button[class="btn btn-default disabled"]`;
 
-    // component count inside the pagination control
-    this.totalComponentCount = `${this.blueprintInputRootElement} .cmpsr-blueprint__inputs__pagination span`;
-
     // filter input
     this.inputFilter = `${this.blueprintInputRootElement} .toolbar-pf .toolbar-pf-actions .toolbar-pf-filter
       input[id="cmpsr-blueprint-input-filter"]`;
-
-    // filter type
-    this.labelFilterType = `${this.blueprintInputRootElement} .toolbar-pf .toolbar-pf-actions .toolbar-pf-filter
-      label[for="cmpsr-blueprint-input-filter"]`;
 
     // filter content label
     this.labelFilterContent = `${this.blueprintInputRootElement} .toolbar-pf .toolbar-pf-results ul li span`;
@@ -87,10 +72,6 @@ module.exports = class EditBlueprintPage extends MainPage {
     // clear all filters link
     this.linkClearAllFilters = `${this.blueprintInputRootElement} .toolbar-pf .toolbar-pf-results .list-inline li a`;
 
-    // filter result
-    this.filterResult = `${this.componentListItemRootElement} .list-pf-container .list-pf-content .list-pf-content-wrapper
-      .list-pf-main-content .list-pf-title`;
-
     // More Action dropdown menu list
     this.moreActionList = {
       Export: 'Export',
@@ -98,60 +79,35 @@ module.exports = class EditBlueprintPage extends MainPage {
 
     this.componentListItemRootElementSelect = `${this.componentListItemRootElement} a`;
 
-    // httpd component
-    this.httpdComponent = `${this.blueprintInputRootElement} .cmpsr-list-pf__compacted
-      div:nth-child(36) .list-pf-container .list-pf-content-wrapper`;
-
-    // httpd + button
-    this.btnHttpdComponent = `${this.blueprintInputRootElement} .cmpsr-list-pf__compacted
-      div:nth-child(36) .list-pf-container a`;
-
-    // the 1st component name
-    this.theFirstComponentName = `${this.blueprintInputRootElement} .cmpsr-list-pf__compacted
-      div:nth-child(1) .list-pf-container .list-pf-content-wrapper .list-pf-main-content div[class="list-pf-title "]`;
-
-    // the 1st + button
-    this.btnTheFirstComponent = `${this.blueprintInputRootElement} .cmpsr-list-pf__compacted
+    // Available Component
+    // List
+    this.availableComponentList = `${this.componentListItemRootElement} .list-pf-content.list-pf-content-flex`;
+    // Name
+    this.availableComponentName = '.list-pf-title';
+    // + Button
+    this.availableComponentPlusButton = '.btn-link .fa-plus';
+    // - Button
+    this.availableComponentMinusButton = '.btn-link .fa-minus';
+    // Icon
+    this.availableComponentIcon = '.list-pf-left span span';
+    // Bordered Icon Class Attribute
+    this.borderedIconClassAttribute = 'pficon pficon-bundle list-pf-icon-bordered list-pf-icon list-pf-icon-small';
+    // Normal Icon Class Attribute
+    this.normalIconClassAttribute = 'pficon pficon-bundle  list-pf-icon list-pf-icon-small';
+    // + Button of the 1st component
+    this.plusButtonOfTheFirstComponent = `${this.blueprintInputRootElement} .cmpsr-list-pf__compacted
       div:nth-child(1) .list-pf-container a`;
-
-    // the 1st + icon
-    this.iconPlusTheFirstComponent = `${this.blueprintInputRootElement} .cmpsr-list-pf__compacted
-      div:nth-child(1) .list-pf-container a span[class="fa fa-plus"]`;
-
-    // the 1st - icon
-    this.iconMinusTheFirstComponent = `${this.blueprintInputRootElement} .cmpsr-list-pf__compacted
-      div:nth-child(1) .list-pf-container a span[class="fa fa-minus"]`;
-
-    // the 1st component icon
-    this.iconTheFirstComponent = `${this.blueprintInputRootElement} .cmpsr-list-pf__compacted
-      div:nth-child(1) .list-pf-container .list-pf-left
-      span[class="pficon pficon-bundle  list-pf-icon list-pf-icon-small"]`;
-
-    // the 1st component bordered icon
-    this.iconBorderedTheFirstComponent = `${this.blueprintInputRootElement} .cmpsr-list-pf__compacted
-      div:nth-child(1) .list-pf-container .list-pf-left
-      span[class="pficon pficon-bundle list-pf-icon-bordered list-pf-icon list-pf-icon-small"]`;
-
-    // the 2nd component name
-    this.theSecondComponentName = `${this.blueprintInputRootElement} .cmpsr-list-pf__compacted
+    // Name of the 1st component
+    this.nameOfTheFirstComponent = `${this.blueprintInputRootElement} .cmpsr-list-pf__compacted
+      div:nth-child(1) .list-pf-container .list-pf-content-wrapper .list-pf-main-content div[class="list-pf-title "]`;
+    // + Button of the 2nd component
+    this.plusButtonOfTheSecondComponent = `${this.blueprintInputRootElement} .cmpsr-list-pf__compacted
+      div:nth-child(2) .list-pf-container a`;
+    // Name of the 2nd component
+    this.nameOfTheSecondComponent = `${this.blueprintInputRootElement} .cmpsr-list-pf__compacted
       div:nth-child(2) .list-pf-container .list-pf-content-wrapper .list-pf-main-content div[class="list-pf-title "]`;
 
-    // the 2nd + button
-    this.btnTheSecondComponent = `${this.blueprintInputRootElement} .cmpsr-list-pf__compacted
-      div:nth-child(2) .list-pf-container a`;
-
     // Body Main elements
-    // Blueprint Components - 1st component
-    this.boxFirstSelectedComponent = `${this.bodyMainRootElement} .cmpsr-blueprint__components div:nth-child(1)`;
-    this.labelFirstComponentName = `${this.bodyMainRootElement} .cmpsr-blueprint__components
-      div:nth-child(1) .list-pf-content .list-pf-title a`;
-
-    // Component Details - Component name label
-    this.labelComponentName = `${this.bodyMainRootElement} .cmpsr-header h3[class="cmpsr-title"] span`;
-
-    // Component Details - Add button
-    this.btnAdd = `${this.bodyMainRootElement} .cmpsr-header .cmpsr-header__actions ul li button`;
-
     // Selected Components content
     this.contentSelectedComponents = 'div[class="list-pf cmpsr-list-pf list-pf-stacked cmpsr-blueprint__components"]';
   }

--- a/test/end-to-end/specs/test_editBlueprint.js
+++ b/test/end-to-end/specs/test_editBlueprint.js
@@ -2,16 +2,13 @@ const assert = require('assert');
 const config = require('../wdio.conf.js');
 
 const testData = config.testData;
-const helper = require('../utils/helper');
 
 const BlueprintsPage = require('../pages/blueprints');
 const CreateBlueprintPage = require('../pages/createBlueprint');
 const DeleteBlueprintPage = require('../pages/deleteBlueprint');
 const EditBlueprintPage = require('../pages/editBlueprint');
 const CreateImagePage = require('../pages/createImage');
-const ToastNotifPage = require('../pages/toastNotif');
 const ExportBlueprintPage = require('../pages/exportBlueprint');
-const ChangesPendingCommitPage = require('../pages/changesPendingCommit');
 
 
 describe('Given Edit Blueprint Page', () => {
@@ -171,22 +168,27 @@ describe('Given Edit Blueprint Page', () => {
         browser
           .waitForVisible(editBlueprintPage.componentListItemRootElementSelect);
 
-        // verify bordered icon
-        browser
-          .waitForVisible(editBlueprintPage.iconBorderedTheFirstComponent);
+        // find the package in the list of filtered results
+        $$(editBlueprintPage.availableComponentList).some((item) => {
+          const title = item.$(editBlueprintPage.availableComponentName).getText();
+          if (title === 'httpd') {
+            const icon = item.$(editBlueprintPage.availableComponentIcon);
+            let iconAttribute = icon.getAttribute('class');
+            // httpd package should have a bordered icon because it's selected components
+            assert.equal(iconAttribute, editBlueprintPage.borderedIconClassAttribute);
 
-        // then remove the selected component from the list
-        browser
-          .waitForVisible(editBlueprintPage.iconMinusTheFirstComponent);
+            // clicks - button to remove httpd from selected components
+            item.$(editBlueprintPage.availableComponentMinusButton).click();
 
-        browser
-          .click(editBlueprintPage.iconMinusTheFirstComponent);
-
-        // and verify that the icon changes back to one without border
-        browser
-          .waitForVisible(editBlueprintPage.iconTheFirstComponent);
-        browser
-          .waitForVisible(editBlueprintPage.iconPlusTheFirstComponent);
+            // wait for + button after clicking - button
+            item.$(editBlueprintPage.availableComponentPlusButton).waitForVisible();
+            browser.pause(5000);
+            // httpd package should have a normal icon because it's not a selected components
+            iconAttribute = icon.getAttribute('class');
+            assert.equal(iconAttribute, editBlueprintPage.normalIconClassAttribute);
+          }
+          return title === 'httpd';
+        });
       });
     });
   });

--- a/test/end-to-end/specs/test_pendingCommit.js
+++ b/test/end-to-end/specs/test_pendingCommit.js
@@ -1,5 +1,4 @@
 const assert = require('assert');
-const helper = require('../utils/helper');
 const config = require('../wdio.conf.js');
 const testData = config.testData;
 
@@ -78,11 +77,11 @@ describe('Changes Pending Commit Page', () => {
 
       // add 1st component to the selection. Note: there's already bash selected
       browser
-        .waitForVisible(editBlueprintPage.btnTheFirstComponent);
+        .waitForVisible(editBlueprintPage.plusButtonOfTheFirstComponent);
 
-      const firstComponent = $(editBlueprintPage.theFirstComponentName).getText();
+      const firstComponent = $(editBlueprintPage.nameOfTheFirstComponent).getText();
       browser
-        .click(editBlueprintPage.btnTheFirstComponent)
+        .click(editBlueprintPage.plusButtonOfTheFirstComponent)
         .waitForVisible(editBlueprintPage.contentSelectedComponents);
 
       browser
@@ -91,11 +90,11 @@ describe('Changes Pending Commit Page', () => {
 
       // add 2nd component to the selection and wait for depsolve to complete
       browser
-        .waitForVisible(editBlueprintPage.btnTheSecondComponent);
+        .waitForVisible(editBlueprintPage.plusButtonOfTheSecondComponent);
 
-      const secondComponent = $(editBlueprintPage.theSecondComponentName).getText();
+      const secondComponent = $(editBlueprintPage.nameOfTheSecondComponent).getText();
       browser
-        .click(editBlueprintPage.btnTheSecondComponent)
+        .click(editBlueprintPage.plusButtonOfTheSecondComponent)
         .waitForVisible(editBlueprintPage.contentSelectedComponents);
 
       browser


### PR DESCRIPTION
1. Remove some useless code from createBlueprint.js and editBlueprint.js
2. Make editVlueprint and pendingCommit test case smarter to work with Fedora 29.
3. Fix a css selector bug which is not easy to reporduce.