### PR TITLE
Set image size

### DIFF
--- a/components/ListView/ListItemImages.js
+++ b/components/ListView/ListItemImages.js
@@ -289,7 +289,8 @@ class ListItemImages extends React.Component {
         </ImagesDataList>
       );
     }
-    const size = Math.round(listItem.image_size / 10000000) / 100;
+    const gigabyte = 1024 * 1024 * 1024;
+    const size = listItem.image_size / gigabyte;
 
     return (
       <DataListItem 

--- a/components/Modal/CreateImageUpload.js
+++ b/components/Modal/CreateImageUpload.js
@@ -544,10 +544,6 @@ class CreateImageUploadModal extends React.Component {
             <Text>{formatMessage(messages.review)}</Text>
             {providerSettings[uploadService] !== undefined && (
               <TextList component={TextListVariants.dl}>
-                <TextListItem component={TextListItemVariants.dt}>
-                  <FormattedMessage defaultMessage="Image name" />
-                </TextListItem>
-                <TextListItem component={TextListItemVariants.dd}>{imageName}</TextListItem>
                 <dt>
                   <FormattedMessage defaultMessage="Image size" />
                 </dt>
@@ -590,6 +586,10 @@ class CreateImageUploadModal extends React.Component {
                     </TextListItem>
                   </React.Fragment>
                 ))}
+                <TextListItem component={TextListItemVariants.dt}>
+                  <FormattedMessage defaultMessage="Image name" />
+                </TextListItem>
+                <TextListItem component={TextListItemVariants.dd}>{imageName}</TextListItem>
                 {Object.keys(providerSettings[uploadService].settings).map(key => (
                   <React.Fragment key={key}>
                     <TextListItem component={TextListItemVariants.dt}>

--- a/components/Modal/CreateImageUpload.js
+++ b/components/Modal/CreateImageUpload.js
@@ -416,9 +416,11 @@ class CreateImageUploadModal extends React.Component {
                     GB
                   </div>
                 </div>
-                {!this.isValidImageSize() && (
+                {imageSize < maxImageSize && imageType !== "" && (
                   <div
-                    className="pf-c-form__helper-text pf-m-error"
+                    className={
+                      !this.isValidImageSize() ? "pf-c-form__helper-text pf-m-error" : "pf-c-form__helper-text"
+                    }
                     id="help-text-simple-form-name-helper"
                     aria-live="polite"
                   >

--- a/components/Modal/CreateImageUpload.js
+++ b/components/Modal/CreateImageUpload.js
@@ -630,6 +630,7 @@ class CreateImageUploadModal extends React.Component {
                   variant="primary"
                   isDisabled={
                     imageType === "" ||
+                    imageSize === "" ||
                     (!this.isValidImageSize() && uploadService.length === 0) ||
                     (this.missingRequiredFields() && activeStep.name === "Review")
                   }

--- a/core/actions/composes.js
+++ b/core/actions/composes.js
@@ -1,9 +1,10 @@
 export const START_COMPOSE = "START_COMPOSE";
-export const startCompose = (blueprintName, composeType, uploadSettings) => ({
+export const startCompose = (blueprintName, composeType, imageSize, uploadSettings) => ({
   type: START_COMPOSE,
   payload: {
     blueprintName,
     composeType,
+    imageSize,
     uploadSettings
   }
 });

--- a/core/composer.js
+++ b/core/composer.js
@@ -180,10 +180,11 @@ export function deleteSource(sourceName) {
   return _delete("/api/v0/projects/source/delete/" + encodeURIComponent(sourceName));
 }
 
-export function startCompose(blueprintName, composeType, uploadSettings) {
+export function startCompose(blueprintName, composeType, imageSize, uploadSettings) {
   return post("/api/v1/compose", {
     blueprint_name: blueprintName,
     compose_type: composeType,
+    size: imageSize,
     upload: uploadSettings,
     branch: "master"
   });

--- a/core/sagas/composes.js
+++ b/core/sagas/composes.js
@@ -22,8 +22,9 @@ import {
 
 function* startCompose(action) {
   try {
-    const { blueprintName, composeType, uploadSettings } = action.payload;
-    const response = yield call(composer.startCompose, blueprintName, composeType, uploadSettings);
+    const { blueprintName, composeType, imageSize, uploadSettings } = action.payload;
+    const imageSizeBytes = imageSize * 1024 * 1024 * 1024;
+    const response = yield call(composer.startCompose, blueprintName, composeType, imageSizeBytes, uploadSettings);
     const statusResponse = yield call(composer.getComposeStatus, response.build_id);
     yield put(fetchingComposeSucceeded(statusResponse.uuids[0]));
     if (statusResponse.uuids[0].queue_status === "WAITING" || statusResponse.uuids[0].queue_status === "RUNNING") {

--- a/public/custom.css
+++ b/public/custom.css
@@ -826,6 +826,7 @@ body {
   line-height: var(--pf-global--LineHeight--md);
 }
 
+
 /* spacing below warning alert in wizard */
 .pf-c-wizard__main-body .pf-c-alert,
 .cc-c-alert__warning  {
@@ -840,4 +841,14 @@ body {
 
 .cc-c-form__required-text {
   margin-bottom: var(--pf-global--gutter);
+}
+
+.cc-c-text__warning-icon {
+  color: var(--pf-global--warning-color--100);
+  vertical-align: -0.125em;
+}
+
+.cc-c-text__danger-icon {
+  color: var(--pf-global--danger-color--100);
+  vertical-align: -0.125em;
 }

--- a/test/verify/check-image
+++ b/test/verify/check-image
@@ -20,6 +20,22 @@ class TestImage(composerlib.ComposerCase):
         # create image wizard (no upload support)
         b.click("li[data-blueprint=httpd-server] #create-image-button")
         b.wait_text("#create-image-upload-wizard #blueprint-name", "httpd-server")
+        # check ? (process length help) button
+        b.click("button[aria-label='process length help']")
+        b.wait_attr("button[aria-label='process length help']", "aria-expanded", "true")
+        b.wait_text(".pf-c-popover__body", "This process can take a while. "
+                    "Images are built in the order they are started.")
+        b.click(".pf-c-popover__content button")
+        b.wait_attr("button[aria-label='process length help']", "aria-expanded", "false")
+        # check ? (image size help) button
+        b.click("button[aria-label='image size help']")
+        b.wait_attr("button[aria-label='image size help']", "aria-expanded", "true")
+        b.wait_text(".pf-c-popover__body",
+                    "Set the size that you want the image to be when instantiated. The total "
+                    "package size and target destination of your image should be considered when "
+                    "setting the image size.")
+        b.click(".pf-c-popover__content button")
+        b.wait_attr("button[aria-label='image size help']", "aria-expanded", "false")
         # check non upload image action (Create only)
         # group actions for select from dropdown menu
         b.wait_visible("#image-type")
@@ -47,6 +63,25 @@ class TestImage(composerlib.ComposerCase):
         # groups action done
         # still keep Create if upload image not selected
         b.wait_text("#continue-button", "Create")
+        # default size = 6GB for ami image
+        b.wait_val("#create-image-size", 6)
+        # change to 1GB = error
+        b.focus("#create-image-size")
+        # delete 6 and input 1
+        b.key_press("\b")
+        b.key_press("1")
+        b.wait_attr("#create-image-upload-wizard button:contains('Create')", "disabled", "")
+        b.wait_attr_contains("#help-text-simple-form-name-helper", "class", "pf-m-error")
+        # delete 1 and input 2001
+        b.key_press("\b")
+        b.key_press("2001")
+        b.wait_in_text("#help-text-simple-form-name-helper",
+                       "The size specified is large. We recommend that you check whether your "
+                       "target destination has any restrictions on image size.")
+        # delete 2001 and input 6
+        b.key_press("\b\b\b\b")
+        b.key_press("6")
+        # b.set_val("#create-image-size", 6)
         # change to Next if upload image selected
         b.click("#aws-checkbox")
         b.click("button:contains('Next')")
@@ -57,7 +92,8 @@ class TestImage(composerlib.ComposerCase):
         b.click("a:contains('Authentication')")
         b.click("a:contains('File upload')")
         b.click("a:contains('Review')")
-        b.wait_in_text(".pf-c-alert__title", "Required information is missing.")
+        b.wait_in_text(".pf-c-alert__title",
+                       "There are one or more fields that require your attention.")
         b.wait_attr("#continue-button", "disabled", "")
         b.click("button:contains('Cancel')")
         b.wait_not_present("#create-image-upload-wizard")


### PR DESCRIPTION
A user may want to manually specify an image size. They may now enter a size into an input field. The size defaults to 2 GB which is also the minimum size allowed. If the size is over 2000 GB an alert is shown explaining that this image may not work on all systems.

This PR is dependent on #868, #767, and https://github.com/osbuild/osbuild-composer/pull/184