### PR TITLE
Rename the osbulid-composer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ On Fedora or Red Hat Enterprise Linux:
 * First install Cockpit on your local machine as described in: https://cockpit-project.org/running.html.
 * Next install and start osbuild-composer:
 ```
-    $ sudo yum install golang-github-osbuild-composer
+    $ sudo yum install osbuild-composer
     $ sudo systemctl start osbuild-composer
 ```
 

--- a/cockpit-composer.spec.in
+++ b/cockpit-composer.spec.in
@@ -12,7 +12,7 @@ BuildRequires:  libappstream-glib
 
 Requires:       cockpit
 Requires:       weldr
-Suggests:       golang-github-osbuild-composer >= 7
+Suggests:       osbuild-composer >= 7
 
 %description
 Composer generates custom images suitable for deploying systems or uploading to


### PR DESCRIPTION
As of F32, the osbuild composer package no longer has the
golang-github prefix in its name. Both the new and old package
names have worked interchangibly since v3 (using Provides) and
will continue to do so until F34, but let's drop this wart sooner
rather than later.

Signed-off-by: Tom Gundersen <teg@jklm.no>