### PR TITLE
prepare to migrate to osbuild organization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ BUILD_RUN = npm run build
 endif
 
 WEBLATE_REPO=tmp/weblate-repo
-WEBLATE_REPO_URL=https://github.com/weldr/cockpit-composer-weblate.git
+WEBLATE_REPO_URL=https://github.com/osbuild/cockpit-composer-weblate.git
 WEBLATE_REPO_BRANCH=master
 
 all: npm-install

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cockpit Composer
 
-[![Build Status](https://travis-ci.org/weldr/cockpit-composer.svg?branch=master)](https://travis-ci.org/weldr/cockpit-composer)
-[![codecov](https://codecov.io/gh/weldr/cockpit-composer/branch/master/graph/badge.svg)](https://codecov.io/gh/weldr/cockpit-composer)
+[![Build Status](https://travis-ci.org/osbuild/cockpit-composer.svg?branch=master)](https://travis-ci.org/osbuild/cockpit-composer)
+[![codecov](https://codecov.io/gh/osbuild/cockpit-composer/branch/master/graph/badge.svg)](https://codecov.io/gh/osbuild/cockpit-composer)
 
 **The web interface for Composer!**
 
@@ -13,7 +13,7 @@ frontend for [osbuild](https://github.com/osbuild).
 
 Here's where to get the code:
 
-    $ git clone https://github.com/weldr/cockpit-composer.git
+    $ git clone https://github.com/osbuild/cockpit-composer.git
     $ cd cockpit-composer/
 
 The remainder of the commands assume you're in the top level of the

--- a/cockpit-composer.spec.in
+++ b/cockpit-composer.spec.in
@@ -5,7 +5,7 @@ Summary:        Composer GUI for use with Cockpit
 
 License:        MIT
 URL:            http://weldr.io/
-Source0:        https://github.com/weldr/cockpit-composer/releases/download/%{version}/cockpit-composer-%{version}.tar.gz
+Source0:        https://github.com/osbuild/cockpit-composer/releases/download/%{version}/cockpit-composer-%{version}.tar.gz
 
 BuildArch:      noarch
 BuildRequires:  libappstream-glib

--- a/test/end-to-end/HACKING.md
+++ b/test/end-to-end/HACKING.md
@@ -2,7 +2,7 @@
 
 Here's where to get the code:
 
-    $ git clone https://github.com/weldr/cockpit-composer.git
+    $ git clone https://github.com/osbuild/cockpit-composer.git
     $ cd test/end-to-end
 
 The remainder of the commands assume you're in the test/end-to-end folder.

--- a/test/end-to-end/specs/blueprints.test.js
+++ b/test/end-to-end/specs/blueprints.test.js
@@ -5,7 +5,7 @@ import Blueprint from "../components/Blueprint.component";
 describe("Blueprints Page", function() {
   let name, description, blueprintComponent;
   before(function() {
-    // blueprint name cannot contain space due to issue https://github.com/weldr/cockpit-composer/issues/317
+    // blueprint name cannot contain space due to issue https://github.com/osbuild/cockpit-composer/issues/317
     // use lorem.slug() ("a-accusantium-repudiandae") instead of lorem.words() ("nulla placeat qui")
     name = faker.lorem.slug();
     description = faker.lorem.sentence();

--- a/test/end-to-end/specs/createImage.test.js
+++ b/test/end-to-end/specs/createImage.test.js
@@ -3,7 +3,7 @@ import Blueprint from "../components/Blueprint.component";
 import createImagePage from "../pages/createImage.page";
 
 describe("Create Image Page", function() {
-  // blueprint name cannot contain space due to issue https://github.com/weldr/cockpit-composer/issues/317
+  // blueprint name cannot contain space due to issue https://github.com/osbuild/cockpit-composer/issues/317
   // use lorem.slug() ("a-accusantium-repudiandae") instead of lorem.words() ("nulla placeat qui")
   const name = faker.lorem.slug();
   const description = faker.lorem.sentence();

--- a/utils/cockpituous-release
+++ b/utils/cockpituous-release
@@ -21,7 +21,7 @@ job release-koji f31
 job release-koji f32
 
 job release-github
-job release-copr @weldr/cockpit-composer
+job release-copr @osbuild/cockpit-composer
 
 # Create a Bodhi update for stable Fedora releases
 job release-bodhi F31


### PR DESCRIPTION
All references to weldr/cockpit-composer are changed to osbuild/cockpit-composer since the url will change when cockpit-composer is migrated from weldr to the osbuild org.

This PR should not be merged until cockpit-composer and cockpit-composer-weblate have been moved to the osbuild organization.