### PR TITLE
components: remove stop option

### DIFF
--- a/components/ListView/ListItemImages.js
+++ b/components/ListView/ListItemImages.js
@@ -157,28 +157,6 @@ class ListItemImages extends React.Component {
           </>
         );
         break;
-      case "RUNNING":
-        actions = (
-          <>
-            <li>
-              <a href="#" role="button" onClick={e => this.handleShowModalStop(e)}>
-                <FormattedMessage defaultMessage="Stop" />
-              </a>
-            </li>
-          </>
-        );
-        break;
-      case "WAITING":
-        actions = (
-          <>
-            <li>
-              <a href="#" role="button" onClick={e => this.handleCancel(e)}>
-                <FormattedMessage defaultMessage="Stop" />
-              </a>
-            </li>
-          </>
-        );
-        break;
       case "FAILED":
         actions = (
           <>


### PR DESCRIPTION
osbuild-composer does not support stopping an image build. Therefore, the stop option has been removed from pending or building images. Thestop modal and the functions related to stopping a build have been kept since this functionality may eventually return.