### PR TITLE
Add AWS help strings and improve review step

### DIFF
--- a/components/Modal/CreateImageUpload.js
+++ b/components/Modal/CreateImageUpload.js
@@ -327,7 +327,7 @@ class CreateImageUploadModal extends React.Component {
             <FormattedMessage defaultMessage="Upload image" />
           </span>
           <Popover
-            id="popover-help"
+            id="aws-provider-popover"
             bodyContent={
               <TextContent>
                 <p>
@@ -413,7 +413,7 @@ class CreateImageUploadModal extends React.Component {
               <div className="pf-c-form__horizontal-group cc-c-popover__horizontal-group">
                 <Text id="blueprint-name">{blueprint.name}</Text>
                 <Popover
-                  id="popover-help"
+                  id="blueprint-name-popover"
                   bodyContent={formatMessage(messages.infotip)}
                   aria-label="process length help"
                 >
@@ -443,7 +443,7 @@ class CreateImageUploadModal extends React.Component {
                   </span>
                 </label>
                 <Popover
-                  id="popover-help"
+                  id="size-popover"
                   bodyContent={formatMessage(messages.imageSizePopover)}
                   aria-label="image size help"
                 >
@@ -516,7 +516,7 @@ class CreateImageUploadModal extends React.Component {
                   </span>
                 </label>
                 <Popover
-                  id="popover-help"
+                  id="access-key-popover"
                   bodyContent={
                     <FormattedMessage
                       defaultMessage="You can create and find existing Access key IDs on the {iam} page in the AWS console."
@@ -552,7 +552,7 @@ class CreateImageUploadModal extends React.Component {
                   </span>
                 </label>
                 <Popover
-                  id="popover-help"
+                  id="secret-key-popover"
                   bodyContent={
                     <FormattedMessage
                       defaultMessage="You can view the Secret access key only when you create a new Access key ID on the {iam} page in the AWS console."
@@ -601,7 +601,7 @@ class CreateImageUploadModal extends React.Component {
                   </span>
                 </label>
                 <Popover
-                  id="popover-help"
+                  id="image-name-popover"
                   bodyContent={
                     <React.Fragment>
                       <FormattedMessage defaultMessage="Provide a file name to be used for the image file that will be uploaded." />
@@ -728,7 +728,7 @@ class CreateImageUploadModal extends React.Component {
           </h3>
           <Popover
             className="pf-l-flex__item"
-            id="popover-help"
+            id="aws-review-popover"
             bodyContent={
               <TextContent>
                 <p>

--- a/components/Modal/CreateImageUpload.js
+++ b/components/Modal/CreateImageUpload.js
@@ -381,7 +381,6 @@ class CreateImageUploadModal extends React.Component {
               defaultMessage: `Upload to AWS`
             })}
             id="aws-checkbox"
-            aria-labelledby="provider-checkbox"
           />
         </div>
       </div>
@@ -445,9 +444,9 @@ class CreateImageUploadModal extends React.Component {
                 <Popover
                   id="size-popover"
                   bodyContent={formatMessage(messages.imageSizePopover)}
-                  aria-label="image size help"
+                  aria-label="Image size help"
                 >
-                  <Button variant="plain" aria-label="image size help">
+                  <Button variant="plain" aria-label="Image size help">
                     <OutlinedQuestionCircleIcon id="popover-icon" />
                   </Button>
                 </Popover>
@@ -525,9 +524,9 @@ class CreateImageUploadModal extends React.Component {
                       }}
                     />
                   }
-                  aria-label="access key id help"
+                  aria-label="Access key ID help"
                 >
-                  <Button variant="plain" aria-label="access key id help">
+                  <Button variant="plain" aria-label="Access key ID help">
                     <OutlinedQuestionCircleIcon id="popover-icon" />
                   </Button>
                 </Popover>
@@ -561,9 +560,9 @@ class CreateImageUploadModal extends React.Component {
                       }}
                     />
                   }
-                  aria-label="secret access key help"
+                  aria-label="Secret access key help"
                 >
-                  <Button variant="plain" aria-label="secret access key help">
+                  <Button variant="plain" aria-label="Secret access key help">
                     <OutlinedQuestionCircleIcon id="popover-icon" />
                   </Button>
                 </Popover>
@@ -607,9 +606,9 @@ class CreateImageUploadModal extends React.Component {
                       <FormattedMessage defaultMessage="Provide a file name to be used for the image file that will be uploaded." />
                     </React.Fragment>
                   }
-                  aria-label="image name help"
+                  aria-label="Image name help"
                 >
-                  <Button variant="plain" aria-label="image name help">
+                  <Button variant="plain" aria-label="Image name help">
                     <OutlinedQuestionCircleIcon id="popover-icon" />
                   </Button>
                 </Popover>
@@ -649,9 +648,9 @@ class CreateImageUploadModal extends React.Component {
                       />
                     </React.Fragment>
                   }
-                  aria-label="bucket help"
+                  aria-label="S3 bucket help"
                 >
-                  <Button variant="plain" aria-label="bucket help">
+                  <Button variant="plain" aria-label="S3 bucket help">
                     <OutlinedQuestionCircleIcon id="popover-icon" />
                   </Button>
                 </Popover>
@@ -693,9 +692,9 @@ class CreateImageUploadModal extends React.Component {
                       }}
                     />
                   }
-                  aria-label="region help"
+                  aria-label="AWS region help"
                 >
-                  <Button variant="plain" aria-label="region help">
+                  <Button variant="plain" aria-label="AWS region help">
                     <OutlinedQuestionCircleIcon id="popover-icon" />
                   </Button>
                 </Popover>
@@ -764,9 +763,9 @@ class CreateImageUploadModal extends React.Component {
                 </p>
               </TextContent>
             }
-            aria-label="aws help"
+            aria-label="AWS help"
           >
-            <Button variant="plain" aria-label="aws help">
+            <Button variant="plain" aria-label="AWS help">
               <OutlinedQuestionCircleIcon id="popover-icon" />
             </Button>
           </Popover>

--- a/components/Modal/CreateImageUpload.js
+++ b/components/Modal/CreateImageUpload.js
@@ -72,6 +72,45 @@ const messages = defineMessages({
   }
 });
 
+const ariaLabels = defineMessages({
+  uploadImage: {
+    id: "upload-image-help",
+    defaultMessage: "Upload image help"
+  },
+  processLength: {
+    id: "provess-length-help",
+    defaultMessage: "Process length help"
+  },
+  imageSize: {
+    id: "image-size-help",
+    defaultMessage: "Image size help"
+  },
+  accessKeyID: {
+    id: "access-key-id-help",
+    defaultMessage: "Access key ID help"
+  },
+  secretAccessKey: {
+    id: "secret-access-key-help",
+    defaultMessage: "Secret access key help"
+  },
+  imageName: {
+    id: "image-name-help",
+    defaultMessage: "Image name help"
+  },
+  bucket: {
+    id: "bucket-help",
+    defaultMessage: "S3 Bucket help"
+  },
+  region: {
+    id: "region-help",
+    defaultMessage: "AWS region help"
+  },
+  aws: {
+    id: "aws-help",
+    defaultMessage: "AWS help"
+  }
+});
+
 class CreateImageUpload extends React.Component {
   constructor(props) {
     super(props);
@@ -364,9 +403,9 @@ class CreateImageUploadModal extends React.Component {
                 </p>
               </TextContent>
             }
-            aria-label="Upload image help"
+            aria-label={formatMessage(ariaLabels.uploadImage)}
           >
-            <Button variant="plain" aria-label="Upload image help">
+            <Button variant="plain" aria-label={formatMessage(ariaLabels.uploadImage)}>
               <OutlinedQuestionCircleIcon id="popover-icon" />
             </Button>
           </Popover>
@@ -414,9 +453,9 @@ class CreateImageUploadModal extends React.Component {
                 <Popover
                   id="blueprint-name-popover"
                   bodyContent={formatMessage(messages.infotip)}
-                  aria-label="process length help"
+                  aria-label={formatMessage(ariaLabels.processLength)}
                 >
-                  <Button variant="plain" aria-label="process length help">
+                  <Button variant="plain" aria-label={formatMessage(ariaLabels.processLength)}>
                     <OutlinedQuestionCircleIcon id="popover-icon" />
                   </Button>
                 </Popover>
@@ -444,9 +483,9 @@ class CreateImageUploadModal extends React.Component {
                 <Popover
                   id="size-popover"
                   bodyContent={formatMessage(messages.imageSizePopover)}
-                  aria-label="Image size help"
+                  aria-label={formatMessage(ariaLabels.imageSize)}
                 >
-                  <Button variant="plain" aria-label="Image size help">
+                  <Button variant="plain" aria-label={formatMessage(ariaLabels.imageSize)}>
                     <OutlinedQuestionCircleIcon id="popover-icon" />
                   </Button>
                 </Popover>
@@ -524,9 +563,9 @@ class CreateImageUploadModal extends React.Component {
                       }}
                     />
                   }
-                  aria-label="Access key ID help"
+                  aria-label={formatMessage(ariaLabels.accessKeyID)}
                 >
-                  <Button variant="plain" aria-label="Access key ID help">
+                  <Button variant="plain" aria-label={formatMessage(ariaLabels.accessKeyID)}>
                     <OutlinedQuestionCircleIcon id="popover-icon" />
                   </Button>
                 </Popover>
@@ -560,9 +599,9 @@ class CreateImageUploadModal extends React.Component {
                       }}
                     />
                   }
-                  aria-label="Secret access key help"
+                  aria-label={formatMessage(ariaLabels.secretAccessKey)}
                 >
-                  <Button variant="plain" aria-label="Secret access key help">
+                  <Button variant="plain" aria-label={formatMessage(ariaLabels.secretAccessKey)}>
                     <OutlinedQuestionCircleIcon id="popover-icon" />
                   </Button>
                 </Popover>
@@ -606,9 +645,9 @@ class CreateImageUploadModal extends React.Component {
                       <FormattedMessage defaultMessage="Provide a file name to be used for the image file that will be uploaded." />
                     </React.Fragment>
                   }
-                  aria-label="Image name help"
+                  aria-label={formatMessage(ariaLabels.imageName)}
                 >
-                  <Button variant="plain" aria-label="Image name help">
+                  <Button variant="plain" aria-label={formatMessage(ariaLabels.imageName)}>
                     <OutlinedQuestionCircleIcon id="popover-icon" />
                   </Button>
                 </Popover>
@@ -648,9 +687,9 @@ class CreateImageUploadModal extends React.Component {
                       />
                     </React.Fragment>
                   }
-                  aria-label="S3 bucket help"
+                  aria-label={formatMessage(ariaLabels.bucket)}
                 >
-                  <Button variant="plain" aria-label="S3 bucket help">
+                  <Button variant="plain" aria-label={formatMessage(ariaLabels.bucket)}>
                     <OutlinedQuestionCircleIcon id="popover-icon" />
                   </Button>
                 </Popover>
@@ -692,9 +731,9 @@ class CreateImageUploadModal extends React.Component {
                       }}
                     />
                   }
-                  aria-label="AWS region help"
+                  aria-label={formatMessage(ariaLabels.region)}
                 >
-                  <Button variant="plain" aria-label="AWS region help">
+                  <Button variant="plain" aria-label={formatMessage(ariaLabels.region)}>
                     <OutlinedQuestionCircleIcon id="popover-icon" />
                   </Button>
                 </Popover>
@@ -763,9 +802,9 @@ class CreateImageUploadModal extends React.Component {
                 </p>
               </TextContent>
             }
-            aria-label="AWS help"
+            aria-label={formatMessage(ariaLabels.aws)}
           >
-            <Button variant="plain" aria-label="AWS help">
+            <Button variant="plain" aria-label={formatMessage(ariaLabels.aws)}>
               <OutlinedQuestionCircleIcon id="popover-icon" />
             </Button>
           </Popover>
@@ -807,8 +846,11 @@ class CreateImageUploadModal extends React.Component {
           <TextContent>
             <Title className="cc-c-popover__horizontal-group" headingLevel="h3" size="2xl">
               <FormattedMessage defaultMessage="Create and upload image" />
-              <Popover bodyContent={formatMessage(messages.infotip)} aria-label="process length help">
-                <Button variant="plain" aria-label="process length help">
+              <Popover
+                bodyContent={formatMessage(messages.infotip)}
+                aria-label={formatMessage(ariaLabels.processLength)}
+              >
+                <Button variant="plain" aria-label={formatMessage(ariaLabels.processLength)}>
                   <OutlinedQuestionCircleIcon id="popover-icon" />
                 </Button>
               </Popover>

--- a/components/Modal/CreateImageUpload.js
+++ b/components/Modal/CreateImageUpload.js
@@ -28,7 +28,6 @@ import NotificationsApi from "../../data/NotificationsApi";
 import BlueprintApi from "../../data/BlueprintApi";
 import { setBlueprint } from "../../core/actions/blueprints";
 import { fetchingQueue, clearQueue, startCompose, fetchingComposeTypes } from "../../core/actions/composes";
-import { fetchingUploadProviders } from "../../core/actions/uploads";
 
 const messages = defineMessages({
   imageSizePopover: {
@@ -134,7 +133,6 @@ class CreateImageUploadModal extends React.Component {
   }
 
   componentWillMount() {
-    this.props.fetchingUploadProviders();
     if (this.props.imageTypes.length === 0) {
       this.props.fetchingComposeTypes();
     }
@@ -210,10 +208,7 @@ class CreateImageUploadModal extends React.Component {
   missingRequiredFields() {
     if (this.state.uploadService.length == 0) return true;
     if (this.state.imageName.length == 0) return true;
-    const settingsLength =
-      Object.keys(this.props.providerSettings[this.state.uploadService].auth).length +
-      Object.keys(this.props.providerSettings[this.state.uploadService].settings).length;
-    if (Object.keys(this.state.uploadSettings).length != settingsLength) return true;
+    if (Object.values(this.state.uploadSettings).some(setting => setting === "")) return true;
     for (const setting in this.state.uploadSettings) {
       if (this.state.uploadSettings[setting].length == 0) return true;
     }
@@ -313,7 +308,7 @@ class CreateImageUploadModal extends React.Component {
 
   render() {
     const { formatMessage } = this.props.intl;
-    const { blueprint, imageTypes, providerSettings } = this.props;
+    const { blueprint, imageTypes } = this.props;
     const {
       showUploadAwsStep,
       showReviewStep,
@@ -438,7 +433,7 @@ class CreateImageUploadModal extends React.Component {
             </FormGroup>
             {imageType === "ami" && awsProviderCheckbox}
             <div className="pf-c-form__group">
-              <div className="pf-c-form__label pf-m-no-padding-top pf-l-flex pf-m-justify-content-flex-start">
+              <div className="pf-c-form__label pf-m-no-padding-top pf-l-flex pf-m-justify-content-flex-start pf-m-nowrap">
                 <label htmlFor="create-image-size" className="pf-l-flex__item">
                   <span className="pf-c-form__label-text">
                     <FormattedMessage defaultMessage="Image size" />
@@ -512,7 +507,7 @@ class CreateImageUploadModal extends React.Component {
           <Form isHorizontal className="cc-m-wide-label">
             <div className="pf-c-form__group">
               <div className="pf-c-form__label pf-m-no-padding-top pf-l-flex pf-m-justify-content-flex-start pf-m-nowrap">
-                <label htmlFor="access-key-id-input" className="pf-c-form__label-text">
+                <label htmlFor="access-key-id-input" className="pf-l-flex__item">
                   <span className="pf-c-form__label-text">
                     <FormattedMessage defaultMessage="Access key ID" />
                   </span>
@@ -548,7 +543,7 @@ class CreateImageUploadModal extends React.Component {
             </div>
             <div className="pf-c-form__group">
               <div className="pf-c-form__label pf-m-no-padding-top pf-l-flex pf-m-justify-content-flex-start pf-m-nowrap">
-                <label htmlFor="secret-access-key-input" className="pf-c-form__label-text">
+                <label htmlFor="secret-access-key-input" className="pf-l-flex__item">
                   <span className="pf-c-form__label-text">
                     <FormattedMessage defaultMessage="Secret access key" />
                   </span>
@@ -597,7 +592,7 @@ class CreateImageUploadModal extends React.Component {
           <Form isHorizontal className="cc-m-wide-label">
             <div className="pf-c-form__group">
               <div className="pf-c-form__label pf-m-no-padding-top pf-l-flex pf-m-justify-content-flex-start pf-m-nowrap">
-                <label htmlFor="image-name-input" className="pf-c-form__label-text">
+                <label htmlFor="image-name-input" className="pf-l-flex__item">
                   <span className="pf-c-form__label-text">
                     <FormattedMessage defaultMessage="Image name" />
                   </span>
@@ -629,7 +624,7 @@ class CreateImageUploadModal extends React.Component {
             </div>
             <div className="pf-c-form__group">
               <div className="pf-c-form__label pf-m-no-padding-top pf-l-flex pf-m-justify-content-flex-start pf-m-nowrap">
-                <label htmlFor="bucket-input" className="pf-c-form__label-text">
+                <label htmlFor="bucket-input" className="pf-l-flex__item">
                   <span className="pf-c-form__label-text">Amazon S3 bucket</span>
                   <span className="pf-c-form__label-required" aria-hidden="true">
                     &#42;
@@ -672,7 +667,7 @@ class CreateImageUploadModal extends React.Component {
             </div>
             <div className="pf-c-form__group">
               <div className="pf-c-form__label pf-m-no-padding-top pf-l-flex pf-m-justify-content-flex-start pf-m-nowrap">
-                <label htmlFor="region-input" className="pf-c-form__label-text">
+                <label htmlFor="region-input" className="pf-l-flex__item">
                   <span className="pf-c-form__label-text">
                     <FormattedMessage defaultMessage="AWS region" />
                   </span>
@@ -725,6 +720,84 @@ class CreateImageUploadModal extends React.Component {
       steps: [awsUploadAuth, awsUploadSettings]
     };
 
+    const awsReviewStep = uploadService === "aws" && (
+      <TextContent>
+        <div className="pf-l-flex">
+          <h3 className="pf-l-flex__item pf-u-mt-2xl pf-u-mb-md">
+            <FormattedMessage defaultMessage="Upload to Amazon" />
+          </h3>
+          <Popover
+            className="pf-l-flex__item"
+            id="popover-help"
+            bodyContent={
+              <TextContent>
+                <p>
+                  <FormattedMessage
+                    defaultMessage="
+                      Image Builder can upload images you create to an {bucket} in AWS and then import them into EC2. When the image build is complete
+                      and the upload action is successful, the image file is available in the AMI section of EC2. Most of the values required to upload
+                      the image can be found in the {console}.
+                    "
+                    values={{
+                      bucket: "S3 bucket",
+                      console: <a href="https://console.aws.amazon.com/console/home">AWS Management Console</a>
+                    }}
+                  />
+                </p>
+                <p>
+                  <FormattedMessage
+                    defaultMessage="
+                      This upload process requires that you have an {iam} role named {vmimport} to ensure that the image can
+                      be imported from the S3 {bucket} into EC2. For more details, refer to the {role}.
+                    "
+                    values={{
+                      bucket: "bucket",
+                      vmimport: <code>vmimport</code>,
+                      iam: "Identity and Access Management (IAM)",
+                      role: (
+                        <a href="https://docs.aws.amazon.com/vm-import/latest/userguide/vmie_prereqs.html#vmimport-role">
+                          AWS Required Service Role
+                        </a>
+                      )
+                    }}
+                  />
+                </p>
+              </TextContent>
+            }
+            aria-label="aws help"
+          >
+            <Button variant="plain" aria-label="aws help">
+              <OutlinedQuestionCircleIcon id="popover-icon" />
+            </Button>
+          </Popover>
+        </div>
+        <TextList className="cc-m-column__fixed-width" component={TextListVariants.dl}>
+          <TextListItem component={TextListItemVariants.dt}>
+            <FormattedMessage defaultMessage="Access key ID" />
+          </TextListItem>
+          <TextListItem component={TextListItemVariants.dd}>
+            {"*".repeat(this.state.uploadSettings["accessKeyID"].length)}
+          </TextListItem>
+          <TextListItem component={TextListItemVariants.dt}>
+            <FormattedMessage defaultMessage="Secret access key" />
+          </TextListItem>
+          <TextListItem component={TextListItemVariants.dd}>
+            {"*".repeat(this.state.uploadSettings["secretAccessKey"].length)}
+          </TextListItem>
+          <TextListItem component={TextListItemVariants.dt}>
+            <FormattedMessage defaultMessage="Image name" />
+          </TextListItem>
+          <TextListItem component={TextListItemVariants.dd}>{imageName}</TextListItem>
+          <TextListItem component={TextListItemVariants.dt}>Amazon S3 bucket</TextListItem>
+          <TextListItem component={TextListItemVariants.dd}>{this.state.uploadSettings["bucket"]}</TextListItem>
+          <TextListItem component={TextListItemVariants.dt}>
+            <FormattedMessage defaultMessage="AWS region" />
+          </TextListItem>
+          <TextListItem component={TextListItemVariants.dd}>{this.state.uploadSettings["region"]}</TextListItem>
+        </TextList>
+      </TextContent>
+    );
+
     const reviewStep = {
       name: "Review",
       component: (
@@ -742,73 +815,43 @@ class CreateImageUploadModal extends React.Component {
               </Popover>
             </Title>
             <Text>{formatMessage(messages.review)}</Text>
-            {providerSettings[uploadService] !== undefined && (
-              <TextList component={TextListVariants.dl}>
-                <dt>
-                  <FormattedMessage defaultMessage="Image size" />
-                </dt>
-                <dd>
-                  {imageSize === "" && (
-                    <div>
-                      <ExclamationCircleIcon className="cc-c-text__danger-icon" />{" "}
-                      {formatMessage(messages.warningSizeEmpty)}
-                    </div>
-                  )}
-                  {imageSize !== "" && <div>{imageSize} GB</div>}
-                  {imageSize < minImageSize && imageSize !== "" && (
-                    <div>
-                      <ExclamationCircleIcon className="cc-c-text__danger-icon" />{" "}
-                      {formatMessage(messages.warningSizeSmall, {
-                        size: minImageSize
-                      })}
-                    </div>
-                  )}
-                  {imageSize > maxImageSize && (
-                    <div>
-                      <ExclamationTriangleIcon className="cc-c-text__warning-icon" />{" "}
-                      {formatMessage(messages.warningSizeLarge)}
-                    </div>
-                  )}
-                </dd>
-                {Object.keys(providerSettings[uploadService].auth).map(key => (
-                  <React.Fragment key={key}>
-                    <TextListItem component={TextListItemVariants.dt}>
-                      {formatMessage({
-                        id: "review-settings",
-                        defaultMessage: providerSettings[uploadService].auth[key].displayText
-                      })}
-                    </TextListItem>
-                    <TextListItem component={TextListItemVariants.dd}>
-                      {providerSettings[uploadService].auth[key].isPassword &&
-                      this.state.uploadSettings[key] != undefined
-                        ? "*".repeat(this.state.uploadSettings[key].length)
-                        : this.state.uploadSettings[key]}
-                    </TextListItem>
-                  </React.Fragment>
-                ))}
-                <TextListItem component={TextListItemVariants.dt}>
-                  <FormattedMessage defaultMessage="Image name" />
-                </TextListItem>
-                <TextListItem component={TextListItemVariants.dd}>{imageName}</TextListItem>
-                {Object.keys(providerSettings[uploadService].settings).map(key => (
-                  <React.Fragment key={key}>
-                    <TextListItem component={TextListItemVariants.dt}>
-                      {formatMessage({
-                        id: "review-settings",
-                        defaultMessage: providerSettings[uploadService].settings[key].displayText
-                      })}
-                    </TextListItem>
-                    <TextListItem component={TextListItemVariants.dd}>
-                      {providerSettings[uploadService].settings[key].isPassword &&
-                      this.state.uploadSettings[key] != undefined
-                        ? "*".repeat(this.state.uploadSettings[key].length)
-                        : this.state.uploadSettings[key]}
-                    </TextListItem>
-                  </React.Fragment>
-                ))}
-              </TextList>
-            )}
+            <h3 className="pf-u-mt-2xl pf-u-mb-md">
+              <FormattedMessage defaultMessage="Image output" />
+            </h3>
+            <TextList className="cc-m-column__fixed-width" component={TextListVariants.dl}>
+              <dt>
+                <FormattedMessage defaultMessage="Image size" />
+              </dt>
+              <dd>
+                {imageSize === "" && (
+                  <div>
+                    <ExclamationCircleIcon className="cc-c-text__danger-icon" />{" "}
+                    {formatMessage(messages.warningSizeEmpty)}
+                  </div>
+                )}
+                {imageSize !== "" && <div>{imageSize} GB</div>}
+                {imageSize < minImageSize && imageSize !== "" && (
+                  <div>
+                    <ExclamationCircleIcon className="cc-c-text__danger-icon" />{" "}
+                    {formatMessage(messages.warningSizeSmall, {
+                      size: minImageSize
+                    })}
+                  </div>
+                )}
+                {imageSize > maxImageSize && (
+                  <div>
+                    <ExclamationTriangleIcon className="cc-c-text__warning-icon" />{" "}
+                    {formatMessage(messages.warningSizeLarge)}
+                  </div>
+                )}
+              </dd>
+              <TextListItem component={TextListItemVariants.dt}>
+                <FormattedMessage defaultMessage="Image type" />
+              </TextListItem>
+              <TextListItem component={TextListItemVariants.dd}>{imageType}</TextListItem>
+            </TextList>
           </TextContent>
+          {awsReviewStep}
         </React.Fragment>
       )
     };
@@ -921,8 +964,6 @@ CreateImageUploadModal.propTypes = {
   clearQueue: PropTypes.func,
   imageTypes: PropTypes.arrayOf(PropTypes.object),
   fetchingComposeTypes: PropTypes.func,
-  providerSettings: PropTypes.objectOf(PropTypes.object),
-  fetchingUploadProviders: PropTypes.func,
   setBlueprint: PropTypes.func,
   intl: intlShape.isRequired,
   startCompose: PropTypes.func,
@@ -939,9 +980,7 @@ CreateImageUploadModal.defaultProps = {
   fetchingQueue: function() {},
   clearQueue: function() {},
   imageTypes: [],
-  providerSettings: {},
   fetchingComposeTypes: function() {},
-  fetchingUploadProviders: function() {},
   setBlueprint: function() {},
   startCompose: function() {},
   layout: {},
@@ -951,8 +990,7 @@ CreateImageUploadModal.defaultProps = {
 const mapStateToProps = state => ({
   composeQueue: state.composes.queue,
   composeQueueFetched: state.composes.queueFetched,
-  imageTypes: state.composes.composeTypes,
-  providerSettings: state.uploads.providerSettings
+  imageTypes: state.composes.composeTypes
 });
 
 const mapDispatchToProps = dispatch => ({
@@ -961,9 +999,6 @@ const mapDispatchToProps = dispatch => ({
   },
   fetchingComposeTypes: () => {
     dispatch(fetchingComposeTypes());
-  },
-  fetchingUploadProviders: () => {
-    dispatch(fetchingUploadProviders());
   },
   fetchingQueue: () => {
     dispatch(fetchingQueue());

--- a/components/Modal/CreateImageUpload.js
+++ b/components/Modal/CreateImageUpload.js
@@ -433,7 +433,7 @@ class CreateImageUploadModal extends React.Component {
             </FormGroup>
             {imageType === "ami" && awsProviderCheckbox}
             <div className="pf-c-form__group">
-              <div className="pf-c-form__label pf-m-no-padding-top pf-l-flex pf-m-justify-content-flex-start pf-m-nowrap">
+              <div className="pf-c-form__label pf-m-no-padding-top pf-l-flex pf-u-display-flex pf-m-justify-content-flex-start pf-m-nowrap">
                 <label htmlFor="create-image-size" className="pf-l-flex__item">
                   <span className="pf-c-form__label-text">
                     <FormattedMessage defaultMessage="Image size" />
@@ -506,7 +506,7 @@ class CreateImageUploadModal extends React.Component {
           </Text>
           <Form isHorizontal className="cc-m-wide-label">
             <div className="pf-c-form__group">
-              <div className="pf-c-form__label pf-m-no-padding-top pf-l-flex pf-m-justify-content-flex-start pf-m-nowrap">
+              <div className="pf-c-form__label pf-m-no-padding-top pf-l-flex pf-u-display-flex pf-m-justify-content-flex-start pf-m-nowrap">
                 <label htmlFor="access-key-id-input" className="pf-l-flex__item">
                   <span className="pf-c-form__label-text">
                     <FormattedMessage defaultMessage="Access key ID" />
@@ -542,7 +542,7 @@ class CreateImageUploadModal extends React.Component {
               />
             </div>
             <div className="pf-c-form__group">
-              <div className="pf-c-form__label pf-m-no-padding-top pf-l-flex pf-m-justify-content-flex-start pf-m-nowrap">
+              <div className="pf-c-form__label pf-m-no-padding-top pf-l-flex pf-u-display-flex pf-m-justify-content-flex-start pf-m-nowrap">
                 <label htmlFor="secret-access-key-input" className="pf-l-flex__item">
                   <span className="pf-c-form__label-text">
                     <FormattedMessage defaultMessage="Secret access key" />
@@ -591,7 +591,7 @@ class CreateImageUploadModal extends React.Component {
           </Text>
           <Form isHorizontal className="cc-m-wide-label">
             <div className="pf-c-form__group">
-              <div className="pf-c-form__label pf-m-no-padding-top pf-l-flex pf-m-justify-content-flex-start pf-m-nowrap">
+              <div className="pf-c-form__label pf-m-no-padding-top pf-l-flex pf-u-display-flex pf-m-justify-content-flex-start pf-m-nowrap">
                 <label htmlFor="image-name-input" className="pf-l-flex__item">
                   <span className="pf-c-form__label-text">
                     <FormattedMessage defaultMessage="Image name" />
@@ -623,7 +623,7 @@ class CreateImageUploadModal extends React.Component {
               />
             </div>
             <div className="pf-c-form__group">
-              <div className="pf-c-form__label pf-m-no-padding-top pf-l-flex pf-m-justify-content-flex-start pf-m-nowrap">
+              <div className="pf-c-form__label pf-m-no-padding-top pf-l-flex pf-u-display-flex pf-m-justify-content-flex-start pf-m-nowrap">
                 <label htmlFor="bucket-input" className="pf-l-flex__item">
                   <span className="pf-c-form__label-text">Amazon S3 bucket</span>
                   <span className="pf-c-form__label-required" aria-hidden="true">
@@ -666,7 +666,7 @@ class CreateImageUploadModal extends React.Component {
               />
             </div>
             <div className="pf-c-form__group">
-              <div className="pf-c-form__label pf-m-no-padding-top pf-l-flex pf-m-justify-content-flex-start pf-m-nowrap">
+              <div className="pf-c-form__label pf-m-no-padding-top pf-l-flex pf-u-display-flex pf-m-justify-content-flex-start pf-m-nowrap">
                 <label htmlFor="region-input" className="pf-l-flex__item">
                   <span className="pf-c-form__label-text">
                     <FormattedMessage defaultMessage="AWS region" />
@@ -722,7 +722,7 @@ class CreateImageUploadModal extends React.Component {
 
     const awsReviewStep = uploadService === "aws" && (
       <TextContent>
-        <div className="pf-l-flex">
+        <div className="pf-l-flex pf-u-display-flex">
           <h3 className="pf-l-flex__item pf-u-mt-2xl pf-u-mb-md">
             <FormattedMessage defaultMessage="Upload to Amazon" />
           </h3>

--- a/main.js
+++ b/main.js
@@ -13,6 +13,7 @@ import { Provider } from "react-redux";
 import "@patternfly/react-core/dist/styles/base.css";
 import "@patternfly/patternfly/patternfly-addons.css";
 import "@patternfly/patternfly/layouts/Flex/flex.css";
+import "@patternfly/react-styles/css/utilities/Display/display.css";
 import "./public/custom.css";
 import "bootstrap";
 import cockpit from "cockpit";

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@patternfly/patternfly": "^2.31.0",
     "@patternfly/react-core": "3.153.13",
     "@patternfly/react-icons": "3.15.16",
+    "@patternfly/react-styles": "^3.7.13",
     "bootstrap": "3.4.1",
     "core-js": "3.6.4",
     "core-js-compat": "3.6.5",

--- a/public/custom.css
+++ b/public/custom.css
@@ -827,7 +827,6 @@ body {
   line-height: var(--pf-global--LineHeight--md);
 }
 
-
 /* spacing below warning alert in wizard */
 .pf-c-wizard__main-body .pf-c-alert,
 .cc-c-alert__warning  {

--- a/public/custom.css
+++ b/public/custom.css
@@ -812,6 +812,7 @@ body {
 
 /* form group checkbox alignment fix */
 .pf-c-form__horizontal-group .pf-c-check,
+.pf-c-form__horizontal-group .pf-c-radio,
 .cc-c-form__static-text {
   padding-top: var(--pf-global--spacer--form-element);
   padding-bottom: var(--pf-global--spacer--form-element);
@@ -839,6 +840,10 @@ body {
   justify-content: space-between;
 }
 
+.cc-c-form__horizontal-align {
+  align-items: baseline;
+}
+
 .cc-c-form__required-text {
   margin-bottom: var(--pf-global--gutter);
 }
@@ -851,4 +856,17 @@ body {
 .cc-c-text__danger-icon {
   color: var(--pf-global--danger-color--100);
   vertical-align: -0.125em;
+}
+
+/* Setting a fixed width similar to the values used in horizontal forms */
+/* var(--pf-c-form--m-horizontal--md__group--GridTemplateColumns)  */
+/* NOTE that 576px is defined as a sass variable in PF source code as min-width: $pf-global--breakpoint--sm */
+@media screen and (min-width: 576px) {
+  .pf-c-content dl.cc-m-column__fixed-width {
+    grid-template-columns: 200px 1fr;
+  }
+}
+
+.pf-c-form.pf-m-horizontal.cc-m-wide-label .pf-c-form__group {
+  grid-template-columns: 200px 1fr;
 }

--- a/test/verify/check-image
+++ b/test/verify/check-image
@@ -90,7 +90,7 @@ class TestImage(composerlib.ComposerCase):
         b.wait_text("#create-image-upload-wizard #blueprint-name", "httpd-server")
         # go to each setion by clicking link directly
         b.click("a:contains('Authentication')")
-        b.click("a:contains('File upload')")
+        b.click("a:contains('Destination')")
         b.click("a:contains('Review')")
         b.wait_in_text(".pf-c-alert__title",
                        "There are one or more fields that require your attention.")

--- a/test/verify/check-image
+++ b/test/verify/check-image
@@ -20,22 +20,22 @@ class TestImage(composerlib.ComposerCase):
         # create image wizard (no upload support)
         b.click("li[data-blueprint=httpd-server] #create-image-button")
         b.wait_text("#create-image-upload-wizard #blueprint-name", "httpd-server")
-        # check ? (process length help) button
-        b.click("button[aria-label='process length help']")
-        b.wait_attr("button[aria-label='process length help']", "aria-expanded", "true")
+        # check ? (Process length help) button
+        b.click("button[aria-label='Process length help']")
+        b.wait_attr("button[aria-label='Process length help']", "aria-expanded", "true")
         b.wait_text(".pf-c-popover__body", "This process can take a while. "
                     "Images are built in the order they are started.")
         b.click(".pf-c-popover__content button")
-        b.wait_attr("button[aria-label='process length help']", "aria-expanded", "false")
+        b.wait_attr("button[aria-label='Process length help']", "aria-expanded", "false")
         # check ? (image size help) button
-        b.click("button[aria-label='image size help']")
-        b.wait_attr("button[aria-label='image size help']", "aria-expanded", "true")
+        b.click("button[aria-label='Image size help']")
+        b.wait_attr("button[aria-label='Image size help']", "aria-expanded", "true")
         b.wait_text(".pf-c-popover__body",
                     "Set the size that you want the image to be when instantiated. The total "
                     "package size and target destination of your image should be considered when "
                     "setting the image size.")
         b.click(".pf-c-popover__content button")
-        b.wait_attr("button[aria-label='image size help']", "aria-expanded", "false")
+        b.wait_attr("button[aria-label='Image size help']", "aria-expanded", "false")
         # check non upload image action (Create only)
         # group actions for select from dropdown menu
         b.wait_visible("#image-type")


### PR DESCRIPTION
Popover help text is added providing an explanation for each field. General help text about uploading to AWS is also added. The structure of the upload and review steps of the CreateImageUpload wizard
have been restructured to enable the help text. The review step is also updated to improve how the fields are organized and presented.

The help text comes from #829 