### PR TITLE
Fix missing image size in action/saga call

### DIFF
--- a/components/Modal/CreateImageUpload.js
+++ b/components/Modal/CreateImageUpload.js
@@ -775,8 +775,8 @@ const mapDispatchToProps = dispatch => ({
   clearQueue: () => {
     dispatch(clearQueue());
   },
-  startCompose: (blueprintName, composeType, upload) => {
-    dispatch(startCompose(blueprintName, composeType, upload));
+  startCompose: (blueprintName, composeType, imageSize, upload) => {
+    dispatch(startCompose(blueprintName, composeType, imageSize, upload));
   }
 });
 


### PR DESCRIPTION
In the CreateImageUpload wizard a user can specify an image size. The image size was missing from the action dispatcher. The image size is now included when calling the start compose action/saga.