### PR TITLE
compose: add ostree commit image types

### DIFF
--- a/core/composer.js
+++ b/core/composer.js
@@ -133,10 +133,12 @@ export function getComposeTypes() {
   const imageTypeLabels = {
     ami: "Amazon Machine Image Disk (.ami)",
     "ext4-filesystem": "Ext4 File System Image (.img)",
+    "fedora-iot-commit": "Fedora IoT Commit (.tar)",
     "live-iso": "Live Bootable ISO (.iso)",
     "partitioned-disk": "Raw Partitioned Disk Image (.img)",
     qcow2: "QEMU QCOW2 Image (.qcow2)",
     openstack: "OpenStack (.qcow2)",
+    "rhel-edge-commit": "RHEL for Edge Commit (.tar)",
     tar: "TAR Archive (.tar)",
     vhd: "Azure Disk Image (.vhd)",
     vmdk: "VMware Virtual Machine Disk (.vmdk)",


### PR DESCRIPTION
These are a bit different than our other image types, but this is the
closest fit I could find without majorly reworking the API/UI.

The image types are not yet part of osbuild-composer, but I think we can
merge this eagerly as they will be ignored in case the backend doesn't
support them.

Two new image types are introduced "Fedora IoT" and "RHEL for Edge",
these are going to be very similar, but obviously available for
Fedora/RHEL respectively.

Signed-off-by: Tom Gundersen <teg@jklm.no>