### PR TITLE
components: Display kebab menu over logs on Images page

### DIFF
--- a/components/ListView/ListItemImages.js
+++ b/components/ListView/ListItemImages.js
@@ -276,7 +276,7 @@ class ListItemImages extends React.Component {
         isExpanded={this.state.uploadsExpanded}
         data-image={`${this.props.blueprint}-${listItem.version}-${listItem.compose_type}`}
       >
-        <DataListItemRow className={`${this.state.logsExpanded ? "cc-m-sticky" : ""}`}>
+        <DataListItemRow>
           {uploadsToggle}
           <div className="cc-c-data-list__item-icon">
             <BuilderImageIcon />

--- a/public/custom.css
+++ b/public/custom.css
@@ -626,12 +626,6 @@ body {
   --pf-c-data-list__item-action--PaddingBottom: var(--pf-global--spacer--sm);
 }
 
-.pf-c-data-list__item-row.cc-m-sticky {
-  position: sticky;
-  top: 0;
-  background: #fff;
-  border-bottom: var(--pf-c-data-list__item-item--BorderTopWidth) solid var(--pf-c-data-list__item-item--BorderTopColor);
-}
 .pf-c-data-list__expandable-content pre {
   border-top: none;
 }


### PR DESCRIPTION
The kebab menu in the Images screen, is overlaid by the log
output, whenever it is displayed.

This can be fixed by removing the sticky position from the list row.
Since the cc-m-sticky isn't used anywhere else ... I've removed it.

Fixes #975