### PR TITLE
Add messaging about empty blueprints

### DIFF
--- a/components/Modal/CreateImageUpload.js
+++ b/components/Modal/CreateImageUpload.js
@@ -47,6 +47,9 @@ const messages = defineMessages({
     id: "empty-blueprint-alert",
     defaultMessage: "This blueprint is empty."
   },
+  warningEmptyBlueprintDesc: {
+    defaultMessage: "A minimal image will be created with only the packages needed to support the selected image type."
+  },
   warningReview: {
     defaultMessage: "There are one or more fields that require your attention."
   },
@@ -478,10 +481,12 @@ class CreateImageUploadModal extends React.Component {
           {blueprint.packages.length == 0 && (
             <Alert
               id="empty-blueprint-alert"
-              variant="warning"
+              variant="info"
               isInline
               title={formatMessage(messages.warningEmptyBlueprint)}
-            />
+            >
+              {formatMessage(messages.warningEmptyBlueprintDesc)}
+            </Alert>
           )}
           <Form isHorizontal className="cc-m-wide-label">
             <div className="pf-c-form__group cc-c-form__horizontal-align">

--- a/pages/blueprintEdit/index.js
+++ b/pages/blueprintEdit/index.js
@@ -67,8 +67,11 @@ const messages = defineMessages({
   addComponentTitle: {
     defaultMessage: "Add Blueprint Components"
   },
-  addComponentMessage: {
-    defaultMessage: "Browse or search for components, then add them to the blueprint."
+  addComponentMessageOne: {
+    defaultMessage: "Browse or search for components, then add them to the blueprint. Or leave the blueprint empty to create a minimal image."
+  },
+  addComponentMessageTwo: {
+    defaultMessage: "The packages needed to support the selected image type are automatically included when creating an image."
   },
   blueprintTitle: {
     defaultMessage: "Blueprint"
@@ -543,7 +546,7 @@ class EditBlueprintPage extends React.Component {
             >
               <EmptyState
                 title={formatMessage(messages.addComponentTitle)}
-                message={formatMessage(messages.addComponentMessage)}
+                message={`${formatMessage(messages.addComponentMessageOne)} ${formatMessage(messages.addComponentMessageTwo)}`}
               />
             </BlueprintContents>
           </div>


### PR DESCRIPTION
Includes messaging to communicate that empty blueprints result in minimal images, and packages needed for selected image types are automatically included.

fixes #973

Added the second statement in the empty state message below:
<img width="856" alt="Screen Shot 2020-06-03 at 4 43 02 PM" src="https://user-images.githubusercontent.com/21063328/83687489-d50aa980-a5b9-11ea-87d5-5befdf26f8fa.png">

Changed the `warning` to an `info` for the Alert, and included an additional description about the minimal image.
<img width="1200" alt="Screen Shot 2020-06-03 at 4 43 20 PM" src="https://user-images.githubusercontent.com/21063328/83687494-d76d0380-a5b9-11ea-915b-5d1c5cc8fd79.png">
