### PR TITLE
test: Fix preferences for new Firefox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,9 +139,12 @@ machine: bots
 	rsync -avR --exclude="bots/machine/machine_core/__pycache__/" bots/machine/testvm.py bots/machine/identity bots/machine/cloud-init.iso bots/machine/machine_core bots/task/testmap.py test
 
 # checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
+# this needs a recent adjustment for firefox 77, so checkout a SHA until cockpit 221 releases
 test/common:
-	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 216
-	git checkout --force FETCH_HEAD -- test/common
+	#git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 221
+	#git checkout --force FETCH_HEAD -- test/common
+	git fetch https://github.com/cockpit-project/cockpit.git
+	git checkout --force bd3086070cc6 -- test/common
 	git reset test/common
 
 # The po-refresh bot expects these specific Makefile targets


### PR DESCRIPTION
Cockpit's CI moved from an old Firefox 69 to the current version and
nightly builds. This requires some additional user preferences which are
fixed in cockpit master, but not in a release yet.

So check out the corresponding SHA from cockpit's test/common. Once
Cockpit 221 gets released, it can go back to cloning the tag.