### PR TITLE
Modals: add ability to create ostree image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,7 @@ test_rpmbuild: buildrpm_image
 $(VM_IMAGE): rpm bots
 	rm -f $(VM_IMAGE) $(VM_IMAGE).qcow2
 	bots/image-customize -v \
+		--resize 20G \
 		-i `pwd`/$(PACKAGE_NAME)-*.noarch.rpm \
 		-i composer-cli \
 		-u $(CURDIR)/test/files:/home/admin \

--- a/cockpit-composer.spec.in
+++ b/cockpit-composer.spec.in
@@ -12,7 +12,7 @@ BuildRequires:  libappstream-glib
 
 Requires:       cockpit
 Requires:       weldr
-Suggests:       osbuild-composer >= 7
+Suggests:       osbuild-composer >= 14
 
 %description
 Composer generates custom images suitable for deploying systems or uploading to

--- a/core/actions/composes.js
+++ b/core/actions/composes.js
@@ -1,10 +1,11 @@
 export const START_COMPOSE = "START_COMPOSE";
-export const startCompose = (blueprintName, composeType, imageSize, uploadSettings) => ({
+export const startCompose = (blueprintName, composeType, imageSize, ostree, uploadSettings) => ({
   type: START_COMPOSE,
   payload: {
     blueprintName,
     composeType,
     imageSize,
+    ostree,
     uploadSettings
   }
 });

--- a/core/composer.js
+++ b/core/composer.js
@@ -182,11 +182,12 @@ export function deleteSource(sourceName) {
   return _delete("/api/v0/projects/source/delete/" + encodeURIComponent(sourceName));
 }
 
-export function startCompose(blueprintName, composeType, imageSize, uploadSettings) {
+export function startCompose(blueprintName, composeType, imageSize, ostree, uploadSettings) {
   return post("/api/v1/compose", {
     blueprint_name: blueprintName,
     compose_type: composeType,
     size: imageSize,
+    ostree: ostree,
     upload: uploadSettings,
     branch: "master"
   });

--- a/core/sagas/composes.js
+++ b/core/sagas/composes.js
@@ -22,9 +22,16 @@ import {
 
 function* startCompose(action) {
   try {
-    const { blueprintName, composeType, imageSize, uploadSettings } = action.payload;
+    const { blueprintName, composeType, imageSize, ostree, uploadSettings } = action.payload;
     const imageSizeBytes = imageSize * 1024 * 1024 * 1024;
-    const response = yield call(composer.startCompose, blueprintName, composeType, imageSizeBytes, uploadSettings);
+    const response = yield call(
+      composer.startCompose,
+      blueprintName,
+      composeType,
+      imageSizeBytes,
+      ostree,
+      uploadSettings
+    );
     const statusResponse = yield call(composer.getComposeStatus, response.build_id);
     yield put(fetchingComposeSucceeded(statusResponse.uuids[0]));
     if (statusResponse.uuids[0].queue_status === "WAITING" || statusResponse.uuids[0].queue_status === "RUNNING") {

--- a/test/verify/check-image
+++ b/test/verify/check-image
@@ -194,7 +194,7 @@ class TestImage(composerlib.ComposerCase):
         # collect code coverage result
         self.check_coverage()
 
-    @unittest.skipIf(os.environ.get("TEST_OS") == "fedora-31", "Does not support ostree image")
+    @unittest.skipUnless(os.environ.get("TEST_OS") == "fedora-32", "Does not support ostree image")
     def testOSTree(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-image
+++ b/test/verify/check-image
@@ -3,6 +3,8 @@
 # checkpoint:
 # 1. create supported image
 
+import os
+import unittest
 import composerlib
 import testlib
 
@@ -189,6 +191,86 @@ class TestImage(composerlib.ComposerCase):
         b.click("#cmpsr-modal-delete button:contains('Delete Image')")
         b.wait_not_present("#{}".format(selector))
 
+        # collect code coverage result
+        self.check_coverage()
+
+    @unittest.skipIf(os.environ.get("TEST_OS") == "fedora-31", "Does not support ostree image")
+    def testOSTree(self):
+        b = self.browser
+        m = self.machine
+
+        if (os.environ.get("TEST_OS") == "fedora-32"):
+            image_type_ostree = "fedora-iot-commit"
+        elif (os.environ.get("TEST_OS") == "rhel-8-3"):
+            image_type_ostree = "rhel-edge-commit"
+
+        self.login_and_go("/composer", authorized=True)
+        b.wait_present("#main")
+
+        # create image wizard
+        b.click("li[data-blueprint=httpd-server] #create-image-button")
+        b.wait_text("#create-image-upload-wizard #blueprint-name", "httpd-server")
+        # group actions for select from dropdown menu
+        b.wait_visible("#image-type")
+        test_selector = "#image-type option[value='{image_type}']".format(
+            image_type=image_type_ostree)
+        b.wait_present(test_selector)
+        value_id = b.attr(test_selector, "value")
+        b.set_val("#image-type", value_id)
+        b.wait_val("#image-type", value_id)
+        b.click("#continue-button")
+        b.wait_not_present("#create-image-upload-wizard")
+        # toast notification
+        b.wait_present("#cmpsr-toast-imageWaiting .pficon-info")
+        b.click("#cmpsr-toast-imageWaiting .pficon-close")
+        b.wait_not_present("#cmpsr-toast-imageWaiting .pficon-info")
+
+        # got to images tab
+        b.click("#httpd-server-name")
+        # correct image name and type
+        with b.wait_timeout(300):
+            b.click("#blueprint-tabs-tab-images")
+            b.wait_present("ul[data-list=images]")
+        # get uuid as part of css selector
+        uuid = m.execute("""
+            composer-cli compose list | grep httpd-server | awk '{print $1}' | head -1
+            """).rstrip()
+        selector = "{}-compose-name".format(uuid)
+
+        image_type = b.attr("li[aria-labelledby={}] [data-image-type]".format(selector),
+                            "data-image-type")
+        self.assertEqual(image_type, image_type_ostree)
+
+        # image building needs more time
+        with b.wait_timeout(1800):
+            b.wait_text("li[aria-labelledby={}] [data-status=true]".format(selector),
+                        "Image build complete")
+        # log should contains rpm, hostname, users stages and tar assembler
+        b.click("button:contains('Logs')")
+        b.wait_in_text("#{}-logs".format(uuid), "Stage org.osbuild.rpm")
+        b.wait_in_text("#{}-logs".format(uuid), "Stage: org.osbuild.rpm-ostree")
+        b.wait_in_text("#{}-logs".format(uuid), "Assembler org.osbuild.ostree.commit")
+        # close logs
+        b.click("button:contains('Logs')")
+
+        # download image
+        b.click("#{}-actions".format(uuid))
+        b.click("a:contains('Download')")
+
+        # delete image cancel first always
+        b.click("#{}-actions".format(uuid))
+        b.wait_attr("#{}-actions".format(uuid), "aria-expanded", "true")
+        b.click("li[aria-labelledby={}] a:contains('Delete')".format(selector))
+        b.wait_attr("#{}-actions".format(uuid), "aria-expanded", "false")
+        b.click("#cmpsr-modal-delete button:contains('Cancel')")
+        b.wait_not_present("#cmpsr-modal-delete")
+        # delete here
+        b.click("#{}-actions".format(uuid))
+        b.wait_attr("#{}-actions".format(uuid), "aria-expanded", "true")
+        b.click("li[aria-labelledby={}] a:contains('Delete')".format(selector))
+        b.wait_attr("#{}-actions".format(uuid), "aria-expanded", "false")
+        b.click("#cmpsr-modal-delete button:contains('Delete Image')")
+        b.wait_not_present("#{}".format(selector))
         # collect code coverage result
         self.check_coverage()
 

--- a/test/vm.install
+++ b/test/vm.install
@@ -4,10 +4,13 @@
 set -eux
 
 # resize root partition to fill free space
-echo -en "n\n\n\n\n\nw\n" | fdisk /dev/vda
-pvcreate /dev/vda3
-vgextend fedora_ibm-p8-kvm-03-guest-02 /dev/vda3
-lvextend -r -l +100%FREE /dev/fedora_ibm-p8-kvm-03-guest-02/root
+OS=$(. /etc/os-release; echo $ID)
+if [ $OS == "fedora" ]; then
+  echo -en "n\n\n\n\n\nw\n" | fdisk /dev/vda
+  pvcreate /dev/vda3
+  vgextend fedora_ibm-p8-kvm-03-guest-02 /dev/vda3
+  lvextend -r -l +100%FREE /dev/fedora_ibm-p8-kvm-03-guest-02/root
+fi
 
 # overriding osbuild-composer repo with nightly
 mkdir -p /etc/osbuild-composer/repositories

--- a/test/vm.install
+++ b/test/vm.install
@@ -3,6 +3,12 @@
 # The application RPM will be installed separately
 set -eux
 
+# resize root partition to fill free space
+echo -en "n\n\n\n\n\nw\n" | fdisk /dev/vda
+pvcreate /dev/vda3
+vgextend fedora_ibm-p8-kvm-03-guest-02 /dev/vda3
+lvextend -r -l +100%FREE /dev/fedora_ibm-p8-kvm-03-guest-02/root
+
 # overriding osbuild-composer repo with nightly
 mkdir -p /etc/osbuild-composer/repositories
 cp /home/admin/files/rhel-8.json /etc/osbuild-composer/repositories


### PR DESCRIPTION
A user can create a fedora-iot-commit or a rhel-edge-commit through the CreateImageUpload Wizard. If a user selects either of these image types they are required to enter an ostree parent and ref.

![ostreeFields](https://user-images.githubusercontent.com/11712857/84030533-86338a00-a994-11ea-81e0-ff955bd31821.png)

@jgiardino I disable the create button if the user does not enter the required Parent and Branch fields but I do not display an explicit error. Do you think I should use an alert on the input box like we do for an invalid image size?

![invalidImageSize](https://user-images.githubusercontent.com/11712857/84030661-b24f0b00-a994-11ea-8f64-223d3436d8ad.png)
