### PR TITLE
test: add the ability to add additional repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ $(VM_IMAGE): rpm bots
 		-i `pwd`/$(PACKAGE_NAME)-*.noarch.rpm \
 		-i composer-cli \
 		-u $(CURDIR)/test/files:/home/admin \
+		-u $(CURDIR)/test/osbuild-mock.repo:/etc/yum.repos.d \
 		-s $(CURDIR)/test/vm.install \
 		$(TEST_OS)
 


### PR DESCRIPTION
# Testing osbuild/osbuild-composer/cockpit-composer

This PR adds support for running the test VM against any `osbuild` or `osbuild-composer` PR. It relies on the RPMs being built by schutzbot and stored in a publicly available repository.

## Prepare the test framework
```
git clone https://github.com/osbuild/cockpit-composer.git
cd cockpit-composer
make bots
bots/image-download rhel-8-3
```

## Optional: add repo overrides (see below)
```
cp ~/Downloads/osbuild-mock.repo test/
```

## Create test VM
```
TEST_OS=rhel-8-3 make vm
```

## Run test VM
```
bots/vm-run rhel-8-3
```
Follow instructions in MOTD to connect. Note that you may want to use cockpit-composer in a private browser session, as it has some issues when connecting to VMs (in my experience).


### Installing alternative osbulid/osbuild-composer RPMs
Note that the cockpit-composer version in the test VM, is whatever is your
current checkout when doing `make vm`.

In order to also test non-shipped versions of osbulid/osbuild-composer, there
is a bit more to it:

Push a (draft) PR with the code you want to test to osbuild-composer. Note
that the osbuild RPMs are built from whatever is in the osbulid submodule,
so you can make a (scratch) commit to point this at whatever you want to
test. You'll need to push this commit to osbulid-composer though, as schutzbot
does not yet build directly from osbuild.

Schutzbot will pick this up, build the RPMs in mock, and upload them to S3,
look in the Schutzbot logs under the mock part for RHEL8.3 to find the repo
file you need in the optional step below. Drop that in place before making your
test VM.
