### PR TITLE
test: add rhel ostree test

### DIFF
--- a/test/verify/check-image
+++ b/test/verify/check-image
@@ -194,7 +194,7 @@ class TestImage(composerlib.ComposerCase):
         # collect code coverage result
         self.check_coverage()
 
-    @unittest.skipUnless(os.environ.get("TEST_OS") == "fedora-32", "Does not support ostree image")
+    @unittest.skipIf(os.environ.get("TEST_OS") == "fedora-31", "Does not support ostree image")
     def testOSTree(self):
         b = self.browser
         m = self.machine

--- a/test/vm.install
+++ b/test/vm.install
@@ -4,14 +4,11 @@
 set -eux
 
 # resize root partition to fill free space
-OS=$(. /etc/os-release; echo $ID)
-if [ $OS == "fedora" ]; then
-  echo -en "n\n\n\n\n\nw\n" | fdisk /dev/vda
-  pvcreate /dev/vda3
-  VG=$(vgs --noheadings -o vg_name)
-  vgextend $VG /dev/vda3
-  lvextend -r -l +100%FREE $VG/root
-fi
+echo -en "n\n\n\n\n\nw\n" | fdisk /dev/vda
+pvcreate /dev/vda3
+VG=$(vgs --noheadings -o vg_name)
+vgextend $VG /dev/vda3
+lvextend -r -l +100%FREE $VG/root
 
 # overriding osbuild-composer repo with nightly
 mkdir -p /etc/osbuild-composer/repositories


### PR DESCRIPTION
With the added support for both fedora-iot-commits and rhel-edge-commits the ostree test now runs on both fedora-32 and rhel-8.

This test won't pass until osbuild-composer v15 is available.