### PR TITLE
test: Stop hardcoding the VG name

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -8,8 +8,9 @@ OS=$(. /etc/os-release; echo $ID)
 if [ $OS == "fedora" ]; then
   echo -en "n\n\n\n\n\nw\n" | fdisk /dev/vda
   pvcreate /dev/vda3
-  vgextend fedora_ibm-p8-kvm-03-guest-02 /dev/vda3
-  lvextend -r -l +100%FREE /dev/fedora_ibm-p8-kvm-03-guest-02/root
+  VG=$(vgs --noheadings -o vg_name)
+  vgextend $VG /dev/vda3
+  lvextend -r -l +100%FREE $VG/root
 fi
 
 # overriding osbuild-composer repo with nightly


### PR DESCRIPTION
It is different in recent Fedora 31/32 images.