### PR TITLE
Add coverity scan github action

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,39 @@
+
+name: Coverity
+on:
+  schedule:
+    - cron: '0 5 * * *' # Daily at 05:00 UTC
+
+jobs:
+  coverity:
+    name: "Test Suite"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: cockpit-composer
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+        with:
+         path: cockpit-composer
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get install nodejs npm
+
+      - name: Download Coverity Tool
+        run: |
+          make coverity-download
+        env:
+         COVERITY_TOKEN: ${{ secrets.COVERITY_TOKEN }}
+
+      - name: Coverity check
+        run: |
+          make coverity-check
+          
+      - name: Upload analysis results
+        run: |
+          make coverity-submit
+        env:
+         COVERITY_TOKEN: ${{ secrets.COVERITY_TOKEN }}
+         COVERITY_EMAIL: ${{ secrets.COVERITY_EMAIL }}


### PR DESCRIPTION
This is based off the coverity setup used in https://github.com/osbuild/osbuild/pull/453. Coverity can be downloaded, the build run, and the results archived and submitted to coverity for analysis. The environment variables COVERITY_EMAIL and COVERITY_TOKEN need to be defined to run coverity from the Makefile. Also, coverity has a build limit so the github action will only run once per day.