### PR TITLE
pages: don't render input list until blueprint is loaded

### DIFF
--- a/pages/blueprintEdit/index.js
+++ b/pages/blueprintEdit/index.js
@@ -571,7 +571,7 @@ class EditBlueprintPage extends React.Component {
         <h3 className="cmpsr-panel__title cmpsr-panel__title--sidebar">
           {formatMessage(messages.listTitleAvailableComps)}
         </h3>
-        {(inputComponents !== undefined && (
+        {((inputComponents !== undefined && blueprint.components !== undefined && blueprint.packages !== undefined) && (
           <div className="cmpsr-panel__body cmpsr-panel__body--sidebar">
             <div className="toolbar-pf">
               <form className="toolbar-pf-actions">
@@ -618,7 +618,7 @@ class EditBlueprintPage extends React.Component {
                 />
               </div>
             </div>
-            {(blueprint.components === undefined || blueprint.components.length === 0) &&
+            {blueprint.components.length === 0 &&
               Object.keys(this.props.blueprintContentsError).length === 0 &&
               componentsFilters.filterValues.length === 0 && (
                 <div className="alert alert-info alert-dismissable">
@@ -644,13 +644,13 @@ class EditBlueprintPage extends React.Component {
                   />
                 </div>
               )}
-            <ComponentInputs
-              label={formatMessage(messages.listTitleAvailableComps)}
-              components={inputComponents[inputs.selectedInputPage]}
-              handleComponentDetails={this.handleComponentDetails}
-              handleAddComponent={this.handleAddComponent}
-              handleRemoveComponent={this.handleRemoveComponent}
-            />
+              <ComponentInputs
+                label={formatMessage(messages.listTitleAvailableComps)}
+                components={inputComponents[inputs.selectedInputPage]}
+                handleComponentDetails={this.handleComponentDetails}
+                handleAddComponent={this.handleAddComponent}
+                handleRemoveComponent={this.handleRemoveComponent}
+              />
           </div>
         )) || (
           <div className="cmpsr-panel__body cmpsr-panel__body--sidebar">


### PR DESCRIPTION
The input list allows users to add and remove components from a blueprint. These actions can not occur if the blueprint is still being fetched. By disabling the input list until the blueprint is loaded the
user is prevented from interacting with the list when it may reflect inaccurate data. 

This will hopefully fix #1005. This test fails when adding a component to the blueprint due to an issue concatenating. The handleAddComponent function concats twice with the blueprint components and blueprint packages. Conditionally rendering the input list should fix this issue.