### PR TITLE
Add empty state when filter returns no available components

### DIFF
--- a/core/actions/inputs.js
+++ b/core/actions/inputs.js
@@ -20,6 +20,15 @@ export const fetchingInputsSucceeded = (filter, selectedInputPage, pageSize, inp
   }
 });
 
+export const FETCHING_FILTER_NO_RESULTS = "FETCHING_FILTER_NO_RESULTS";
+export const fetchingFilterNoResults = (filter, pageSize) => ({
+  type: FETCHING_FILTER_NO_RESULTS,
+  payload: {
+    filter,
+    pageSize
+  }
+});
+
 export const FETCHING_INPUT_DETAILS = "FETCHING_INPUT_DETAILS";
 export const fetchingInputDetails = component => ({
   type: FETCHING_INPUT_DETAILS,

--- a/core/composer.js
+++ b/core/composer.js
@@ -99,7 +99,7 @@ export function listModules(filter, selectedInputPage, pageSize) {
   const page = selectedInputPage * pageSize;
   return get("/api/v0/modules/list/" + encodeURIComponent(filter), {
     params: { limit: pageSize, offset: page }
-  }).then(response => [response.modules, response.total]);
+  });
 }
 
 /*

--- a/core/reducers/inputs.js
+++ b/core/reducers/inputs.js
@@ -1,5 +1,6 @@
 import {
   FETCHING_INPUTS_SUCCEEDED,
+  FETCHING_FILTER_NO_RESULTS,
   SET_SELECTED_INPUT_PAGE,
   CLEAR_SELECTED_INPUT,
   SET_SELECTED_INPUT,
@@ -31,6 +32,13 @@ const inputs = (state = [], action) => {
         totalInputs: action.payload.total,
         pageSize: action.payload.pageSize
       });
+    case FETCHING_FILTER_NO_RESULTS:
+      return Object.assign({}, state, {
+        inputFilters: action.payload.filter,
+        inputComponents: [[]],
+        totalInputs: 0,
+        pageSize: action.payload.pageSize
+      })
     case SET_SELECTED_INPUT_PAGE:
       return Object.assign({}, state, { selectedInputPage: action.payload.selectedInputPage });
     case CLEAR_SELECTED_INPUT:

--- a/core/sagas/inputs.js
+++ b/core/sagas/inputs.js
@@ -3,6 +3,7 @@ import * as composer from "../composer";
 import {
   FETCHING_INPUTS,
   fetchingInputsSucceeded,
+  fetchingFilterNoResults,
   FETCHING_INPUT_DETAILS,
   FETCHING_INPUT_DEPS,
   FETCHING_DEP_DETAILS,
@@ -42,8 +43,8 @@ function* fetchInputs(action) {
     const { filter, selectedInputPage, pageSize } = action.payload;
     const filter_value = `*${filter.value}*`.replace("**", "*");
     const response = yield call(composer.listModules, filter_value, selectedInputPage, pageSize);
-    const total = response[1];
-    const inputNames = response[0].map(input => input.name).join(",");
+    const total = response.total;
+    const inputNames = response.modules.map(input => input.name).join(",");
     const inputs = yield call(composer.getComponentInfo, inputNames);
     const updatedInputs = flattenInputs(inputs).map(input => {
       const inputData = Object.assign(
@@ -57,7 +58,12 @@ function* fetchInputs(action) {
     });
     yield put(fetchingInputsSucceeded(filter, selectedInputPage, pageSize, updatedInputs, total));
   } catch (error) {
-    console.log("Error in fetchInputsSaga", error);
+    const { filter, pageSize } = action.payload;
+    if (filter.value !== "") {
+      yield put(fetchingFilterNoResults(filter, pageSize));
+    } else {
+      console.log("Error in fetchInputsSaga", error);
+    }
   }
 }
 

--- a/pages/blueprintEdit/index.js
+++ b/pages/blueprintEdit/index.js
@@ -81,6 +81,12 @@ const messages = defineMessages({
   },
   filterByPlaceholder: {
     defaultMessage: "Filter By Name..."
+  },
+  emptyStateNoResultsMessage: {
+    defaultMessage: "Modify your filter criteria to get results."
+  },
+  emptyStateNoResultsTitle: {
+    defaultMessage: "No Results Match the Filter Criteria"
   }
 });
 
@@ -131,7 +137,6 @@ class EditBlueprintPage extends React.Component {
       };
       this.props.fetchingInputs(filter, 0, this.props.inputs.pageSize);
       this.props.setSelectedInputPage(0);
-      // TODO handle the case where no results are returned
       $("#cmpsr-blueprint-input-filter").blur();
       event.preventDefault();
     }
@@ -609,13 +614,15 @@ class EditBlueprintPage extends React.Component {
                     </li>
                   </ul>
                 )}
-                <Pagination
-                  cssClass="cmpsr-blueprint__inputs__pagination"
-                  currentPage={inputs.selectedInputPage}
-                  totalItems={inputs.totalInputs}
-                  pageSize={inputs.pageSize}
-                  handlePagination={this.handlePagination}
-                />
+                {inputs.totalInputs > 0 && (
+                  <Pagination
+                    cssClass="cmpsr-blueprint__inputs__pagination"
+                    currentPage={inputs.selectedInputPage}
+                    totalItems={inputs.totalInputs}
+                    pageSize={inputs.pageSize}
+                    handlePagination={this.handlePagination}
+                  />
+                )}
               </div>
             </div>
             {blueprint.components.length === 0 &&
@@ -644,6 +651,18 @@ class EditBlueprintPage extends React.Component {
                   />
                 </div>
               )}
+            {inputs.inputFilters !== undefined && 
+              inputs.inputFilters.value.length > 0 && 
+              inputComponents[inputs.selectedInputPage].length === 0 && (
+                <EmptyState
+                  title={formatMessage(messages.emptyStateNoResultsTitle)}
+                  message={formatMessage(messages.emptyStateNoResultsMessage)}
+                >
+                  <button className="btn btn-link" type="button" onClick={e => this.handleClearFilters(e)}>
+                    <FormattedMessage defaultMessage="Clear All Filters" />
+                  </button>
+                </EmptyState>
+            ) || (
               <ComponentInputs
                 label={formatMessage(messages.listTitleAvailableComps)}
                 components={inputComponents[inputs.selectedInputPage]}
@@ -651,6 +670,7 @@ class EditBlueprintPage extends React.Component {
                 handleAddComponent={this.handleAddComponent}
                 handleRemoveComponent={this.handleRemoveComponent}
               />
+            )}
           </div>
         )) || (
           <div className="cmpsr-panel__body cmpsr-panel__body--sidebar">

--- a/public/custom.css
+++ b/public/custom.css
@@ -513,6 +513,12 @@ body {
   margin-top: 0
 }
 
+.cmpsr-panel__body--sidebar .blank-slate-pf {
+  background: none;
+  border: none;
+  padding: 0;
+}
+
 .cmpsr-alert-blank-slate {
   margin-bottom: 5px;
 }


### PR DESCRIPTION
This update displays an empty state in the Available Components panel, shown below, when a specified filter returns no results. This is the same messaging we display in the Blueprint Components panel, but additional css is included so that the empty state component fits with the current styling of the side panel. 

<img width="1174" alt="Screen Shot 2020-06-26 at 2 30 32 PM" src="https://user-images.githubusercontent.com/21063328/85890443-56211f00-b7bb-11ea-8492-a1d1fb652d94.png">