### PR TITLE
test: allow selinux journal messages

### DIFF
--- a/test/verify/check-image
+++ b/test/verify/check-image
@@ -271,6 +271,8 @@ class TestImage(composerlib.ComposerCase):
         b.wait_attr("#{}-actions".format(uuid), "aria-expanded", "false")
         b.click("#cmpsr-modal-delete button:contains('Delete Image')")
         b.wait_not_present("#{}".format(selector))
+        self.allow_journal_messages(".*avc:  denied.*",
+                                    ".*audit: .*seresult=denied .*")
         # collect code coverage result
         self.check_coverage()
 


### PR DESCRIPTION
The ostree test was failing due to an avc and selinux denial. The test has been updated to ignore these journal messages. This is a temporary fix for #1022 until these messages are no longer printed.