### PR TITLE
pages: remove undefined check on users

### DIFF
--- a/pages/blueprint/index.js
+++ b/pages/blueprint/index.js
@@ -462,7 +462,7 @@ class BlueprintPage extends React.Component {
                       <FormattedMessage defaultMessage="Users" />
                     </label>
                     <div className="col-sm-10">
-                      {users !== undefined && users.length > 0 && (
+                      {users.length > 0 && (
                         <div>
                           <Table
                             variant={TableVariant.compact}


### PR DESCRIPTION
Checking if users is undefined is useless since users cannot be undefined since it is set locally. This was causing a coverity error
because we accessed users before the undefined check. This check is now removed.