### PR TITLE
components: refactor handleUpdateComponent

### DIFF
--- a/components/ListView/ComponentDetailsView.js
+++ b/components/ListView/ComponentDetailsView.js
@@ -207,9 +207,7 @@ class ComponentDetailsView extends React.Component {
                     <button
                       className="btn btn-primary"
                       type="button"
-                      onClick={(e) => {
-                        return handleUpdateComponent(e, component.name, component.builds[selectedBuildIndex].version);
-                      }}
+                      onClick={(e) => handleUpdateComponent(e, component, component.builds[selectedBuildIndex].version)}
                     >
                       <FormattedMessage defaultMessage="Apply Change" />
                     </button>

--- a/pages/blueprintEdit/index.js
+++ b/pages/blueprintEdit/index.js
@@ -235,7 +235,8 @@ class EditBlueprintPage extends React.Component {
     event.stopPropagation();
   }
 
-  handleUpdateComponent(event, name, version) {
+  handleUpdateComponent(event, component, version) {
+    const name = component.name;
     this.props.clearSelectedInput();
     const selectedComponents = this.props.blueprint.packages.concat(this.props.blueprint.modules);
     const oldVersion = selectedComponents.find((component) => component.name === name).version;


### PR DESCRIPTION
There is an implicit_this coverity issue #1009 with the call to handleUpdateComponent from the ComponentDetailsView. The function call has been refactored to follow the same pattern as the call to handleAddComponent which does not have a coverity issue.