### PR TITLE
Fix wizard's review step type field

### DIFF
--- a/components/Wizard/CreateImageUpload.js
+++ b/components/Wizard/CreateImageUpload.js
@@ -399,6 +399,7 @@ class CreateImageUploadModal extends React.Component {
           imageName={this.state.imageName}
           imageSize={this.state.imageSize}
           imageType={this.state.imageType}
+          imageTypes={this.props.imageTypes}
           minImageSize={this.state.minImageSize}
           maxImageSize={this.state.maxImageSize}
           uploadService={this.state.uploadService}

--- a/components/Wizard/ReviewStep.js
+++ b/components/Wizard/ReviewStep.js
@@ -62,6 +62,7 @@ class ReviewStep extends React.PureComponent {
       imageName,
       imageSize,
       imageType,
+      imageTypes,
       minImageSize,
       maxImageSize,
       missingRequiredFields,
@@ -280,7 +281,9 @@ class ReviewStep extends React.PureComponent {
             <TextListItem component={TextListItemVariants.dt}>
               <FormattedMessage defaultMessage="Image type" />
             </TextListItem>
-            <TextListItem component={TextListItemVariants.dd}>{imageType}</TextListItem>
+            <TextListItem component={TextListItemVariants.dd}>
+              {imageTypes.find((type) => type.name === imageType).label}
+            </TextListItem>
           </TextList>
         </TextContent>
         {awsReviewStep}
@@ -294,6 +297,7 @@ ReviewStep.propTypes = {
   intl: intlShape.isRequired,
   imageName: PropTypes.string,
   imageType: PropTypes.string,
+  imageTypes: PropTypes.arrayOf(PropTypes.object),
   imageSize: PropTypes.number,
   minImageSize: PropTypes.number,
   maxImageSize: PropTypes.number,
@@ -305,6 +309,7 @@ ReviewStep.propTypes = {
 ReviewStep.defaultProps = {
   imageName: "",
   imageType: "",
+  imageTypes: [],
   imageSize: undefined,
   minImageSize: 0,
   maxImageSize: 2000,


### PR DESCRIPTION
In the review step the image type displays  as the image type's label. It was displaying as the image type's name which is less descriptive than the label.

This depends on #1035
This fixes #960