### PR TITLE
spec: change weldr requirement

### DIFF
--- a/cockpit-composer.spec.in
+++ b/cockpit-composer.spec.in
@@ -11,8 +11,12 @@ BuildArch:      noarch
 BuildRequires:  libappstream-glib
 
 Requires:       cockpit
-Requires:       weldr
-Suggests:       osbuild-composer >= 14
+%if 0%{?fedora} >= 33 || 0%{?rhel} >= 8
+Requires: osbuild-composer >= 14
+%else
+Requires: weldr
+Suggests: osbuild-composer >= 14
+%endif
 
 %description
 Composer generates custom images suitable for deploying systems or uploading to


### PR DESCRIPTION
The "Suggests" hint does not always resolve our dependencies as desired so, for new releases, cockpit-composer specifically requires osbuild-composer. For distros that cockpit-composer has already released into, the "weldr" group remains the requirement so that users already running osbuild-composer as the backend can continue to use it instead of lorax-composer. But, if osbuild-composer is unavailable, lorax is installed instead.

This fixes #1040 