### PR TITLE
enable filtering with multiple values or wildcards

### DIFF
--- a/core/sagas/inputs.js
+++ b/core/sagas/inputs.js
@@ -41,7 +41,12 @@ function flattenInputs(response) {
 function* fetchInputs(action) {
   try {
     const { filter, selectedInputPage, pageSize } = action.payload;
-    const filterValue = `*${filter.value}*`.replace("**", "*");
+    const wildcardsUsed = filter.value.includes("*");
+    const regex = / +|, +/g;
+    let filterValue = filter.value.replace(regex, ",");
+    const regexStrip = /(^,+)|(,+$)/g;
+    filterValue = filterValue.replace(regexStrip, "");
+    filterValue = wildcardsUsed ? filterValue : `*${filterValue}*`.replace(/,/g, "*,*");
     // page is displayed in UI starting from 1 but api starts from 0
     const pageIndex = selectedInputPage - 1;
     const response = yield call(composer.listModules, filterValue, pageIndex, pageSize);


### PR DESCRIPTION
The API currently supports the following use cases in the string it accepts:
- User specifies multiple comma-separated values
- User specifies a wildcard

Currently, the UI takes whatever the user input is and wraps it with a wildcard. This results in a couple of issues in the case where the user intends to use a wildcard (e.g. "httpd*" for only packages starting with "httpd") or where the user wants to specify multiple filter values (as noted in #1026). 

This PR addresses both use cases:
- If multiple filter values are provided separated by comma and/or space, then these separators (i.e. " " or ", ") are converted to commas (i.e. ",").
- If the filter value includes at least one wildcard, then the filter value provided to the api uses the wildcards as entered, otherwise, the filter value is wrapped with wildcards.

fixes #1026