### PR TITLE
components: add display flag for undo redo in BlueprintToolbar

### DIFF
--- a/components/Toolbar/BlueprintToolbar.js
+++ b/components/Toolbar/BlueprintToolbar.js
@@ -38,7 +38,7 @@ const BlueprintToolbar = (props) => (
           </button>
         ))}
     </div>
-    {props.undo !== undefined && (
+    {props.showUndoRedo && props.undo !== undefined && (
       <div className="form-group">
         {(props.pastLength > 0 && (
           <button
@@ -96,6 +96,7 @@ BlueprintToolbar.propTypes = {
   futureLength: PropTypes.number,
   redo: PropTypes.func,
   blueprintId: PropTypes.string,
+  showUndoRedo: PropTypes.bool,
 };
 
 BlueprintToolbar.defaultProps = {
@@ -113,6 +114,7 @@ BlueprintToolbar.defaultProps = {
   futureLength: 0,
   redo() {},
   blueprintId: "",
+  showUndoRedo: false,
 };
 
 export default BlueprintToolbar;

--- a/pages/blueprint/index.js
+++ b/pages/blueprint/index.js
@@ -501,6 +501,7 @@ class BlueprintPage extends React.Component {
                     componentsSortValue={this.props.componentsSortValue}
                     componentsSortSetValue={this.props.componentsSortSetValue}
                     dependenciesSortSetValue={this.props.dependenciesSortSetValue}
+                    showUndoRedo={false}
                   />
                   <BlueprintContents
                     components={selectedComponents}

--- a/pages/blueprintEdit/index.js
+++ b/pages/blueprintEdit/index.js
@@ -517,6 +517,7 @@ class EditBlueprintPage extends React.Component {
                 redo={this.props.redo}
                 pastLength={pastLength}
                 futureLength={futureLength}
+                showUndoRedo
               />
             )}
             <BlueprintContents


### PR DESCRIPTION
On the blueprint page we do not want to show the undo redo buttons. There is now a flag passed to the toolbar telling to let it know if it should display these buttons.

Fixes #1050 