### PR TITLE
lib/patternfly: fix red hat font weights

### DIFF
--- a/lib/patternfly/_fonts.scss
+++ b/lib/patternfly/_fonts.scss
@@ -21,16 +21,16 @@ $relative: true
 
 @include printRedHatFont(700, "Bold", $familyName: "RedHatDisplay");
 @include printRedHatFont(700, "BoldItalic", $style: "italic", $familyName: "RedHatDisplay");
-@include printRedHatFont(300, "Black", $familyName: "RedHatDisplay");
-@include printRedHatFont(300, "BlackItalic", $style: "italic", $familyName: "RedHatDisplay");
+@include printRedHatFont(900, "Black", $familyName: "RedHatDisplay");
+@include printRedHatFont(900, "BlackItalic", $style: "italic", $familyName: "RedHatDisplay");
 @include printRedHatFont(300, "Italic", $style: "italic", $familyName: "RedHatDisplay");
 @include printRedHatFont(400, "Medium", $familyName: "RedHatDisplay");
 @include printRedHatFont(400, "MediumItalic", $style: "italic", $familyName: "RedHatDisplay");
 @include printRedHatFont(300, "Regular", $familyName: "RedHatDisplay");
 
-@include printRedHatFont(300, "Bold");
-@include printRedHatFont(300, "BoldItalic", $style: "italic");
-@include printRedHatFont(300, "Italic");
+@include printRedHatFont(700, "Bold");
+@include printRedHatFont(700, "BoldItalic", $style: "italic");
+@include printRedHatFont(400, "Italic", $style: "italic");
 @include printRedHatFont(700, "Medium");
 @include printRedHatFont(700, "MediumItalic", $style: "italic");
 @include printRedHatFont(400, "Regular");


### PR DESCRIPTION
Rewritting prior message:

Font weights are now fetched from https://github.com/RedHatOfficial/RedHatFont/blob/master/webfonts/red-hat-font.css

Information on the Red Hat fonts is available in multiple locations such as google fonts. We now only follow the font weights and weighted names listed in the official repository.

This PR requires changes to cockpit first since we fetch our fonts from cockpit. This will remain a draft until then.