### PR TITLE
Updates function failing coverity scan

### DIFF
--- a/pages/blueprintEdit/index.js
+++ b/pages/blueprintEdit/index.js
@@ -234,11 +234,12 @@ class EditBlueprintPage extends React.Component {
     const name = component.name;
     this.props.clearSelectedInput();
     const selectedComponents = this.props.blueprint.packages.concat(this.props.blueprint.modules);
-    const oldVersion = selectedComponents.find((component) => component.name === name).version;
+    const oldVersion = selectedComponents.find((selectedComp) => selectedComp.name === name).version;
     const updatedComponent = {
       name,
       version,
     };
+    // let??
     const pendingChange = {
       componentOld: `${name}-${oldVersion}`,
       componentNew: `${name}-${version}`,
@@ -250,24 +251,24 @@ class EditBlueprintPage extends React.Component {
       // then only list this component once in the list of changes,
       // where the change shows the old version of the previous change
       pendingChange.componentOld = prevChange.componentOld;
-      pendingChanges = pendingChanges.filter((component) => component !== prevChange);
+      pendingChanges = pendingChanges.filter((change) => change !== prevChange);
     }
     if (prevChange === undefined || pendingChange.componentOld !== pendingChange.componentNew) {
       pendingChanges = [pendingChange].concat(pendingChanges);
     }
     let { packages } = this.props.blueprint;
     let { modules } = this.props.blueprint;
-    if (modules.some((component) => component.name === name)) {
+    if (modules.some((module) => module.name === name)) {
       modules = modules.filter((item) => item.name !== updatedComponent.name).concat(updatedComponent);
     } else {
       packages = packages.filter((item) => item.name !== updatedComponent.name).concat(updatedComponent);
     }
-    const components = this.props.blueprint.components.map((component) => {
-      if (component.name === name) {
-        const componentData = { ...component, name, version, userSelected: true, inBlueprint: true };
+    const components = this.props.blueprint.components.map((blueprintComp) => {
+      if (blueprintComp.name === name) {
+        const componentData = { ...blueprintComp, name, version, userSelected: true, inBlueprint: true };
         return componentData;
       }
-      return component;
+      return blueprintComp;
     });
     this.props.updateBlueprintComponents(this.props.blueprint.id, components, packages, modules, pendingChanges);
     event.preventDefault();


### PR DESCRIPTION
This is another attempt at addressing the coverity failure by changing all instances of `component` that are not based on the argument passed in the function to something else.

The coverity issue flags the following in ComponentDetailsView.js:
`onClick={(e) => handleUpdateComponent(e, component, component.builds[selectedBuildIndex].version)}`
And describes the issue as `EXPLICIT_THIS_EXPECTED` along with other details.

A google search for `EXPLICIT_THIS_EXPECTED` returns a [PDF](https://www.synopsys.com/content/dam/synopsys/sig-assets/datasheets/coverity-cwe-coverage.pdf) with the following additional description of the issue: `Function Call with Incorrectly Specified Arguments`. A google search for this description provides additional [details](https://cwe.mitre.org/data/definitions/628.html) that lead me to think that maybe the issue is more about the arguments passed in the function versus how the function is called (which is kinda what the original issue seems to imply, but _maybe_ those details are incorrect... additionally, the things flagged in this function are present in other functions without being flagged, so I'm inclined to think this scan is slightly off in how it communicates failures). 

This is a shot in the dark, but since one of the arguments is named `component`, I changed any instances of `component` that are not based on this argument (i.e. nested within a new context). And, this issue does not seem to be present in any of the other similar functions that are not being flagged, so 🤞. 

<img width="109" alt="image" src="https://user-images.githubusercontent.com/21063328/89078076-a3138a80-d351-11ea-9002-4e2cf1a6f47b.png">


