### PR TITLE
cockpituous: Release to Fedora 33

### DIFF
--- a/utils/cockpituous-release
+++ b/utils/cockpituous-release
@@ -19,6 +19,7 @@ job release-srpm -V
 job release-koji master
 job release-koji f31
 job release-koji f32
+job release-koji f33
 
 job release-github
 job release-copr @osbuild/cockpit-composer
@@ -26,3 +27,4 @@ job release-copr @osbuild/cockpit-composer
 # Create a Bodhi update for stable Fedora releases
 job release-bodhi F31
 job release-bodhi F32
+job release-bodhi F33


### PR DESCRIPTION
Bodhi activation point is the [next Tuesday](https://fedorapeople.org/groups/schedule/f-33/f-33-key-tasks.html).
Please DON'T merge this if you will have release in the meantime.

I'll start preparing F33 image now so you can test it on F33 as well. Feel free to block until you know it works on F33.