### PR TITLE
test: add rhel-8-beta repo as well

### DIFF
--- a/test/vm.install
+++ b/test/vm.install
@@ -12,7 +12,8 @@ lvextend -r -l +100%FREE $VG/root
 
 # overriding osbuild-composer repo with nightly
 mkdir -p /etc/osbuild-composer/repositories
-cp /home/admin/files/rhel-8.json /etc/osbuild-composer/repositories
+cp /home/admin/files/rhel-8.json /etc/osbuild-composer/repositories/rhel-8.json
+cp /home/admin/files/rhel-8.json /etc/osbuild-composer/repositories/rhel-8-beta.json
 
 # Allow cockpit port (9090) in INPUT chain
 # Do not reload firewall rule during image generation


### PR DESCRIPTION
In order to work both against RHEL8.3 Beta, and RHEL8.3 GA,
osbuild-composer had to split the repo files for the two cases. This was
done in commit
https://github.com/osbuild/osbuild-composer/commit/cc677dea3cabcf44c5debd87c5dbd99f2a3ad8c3
which will have to be back-ported to RHEL8.3. Make sure the
cockpit-composer tests continue to work when that's been done.

Signed-off-by: Tom Gundersen <teg@jklm.no>