### PR TITLE
pages: translate edit blueprint page pagination

### DIFF
--- a/pages/blueprintEdit/index.js
+++ b/pages/blueprintEdit/index.js
@@ -89,6 +89,9 @@ const messages = defineMessages({
   emptyStateNoResultsTitle: {
     defaultMessage: "No Results Match the Filter Criteria",
   },
+  paginationPerPage: {
+    defaultMessage: "per page",
+  },
 });
 
 class EditBlueprintPage extends React.Component {
@@ -584,6 +587,9 @@ class EditBlueprintPage extends React.Component {
                   onPerPageSelect={this.handlePageSizeSelect}
                   isCompact
                   variant={PaginationVariant.bottom}
+                  titles={{
+                    perPageSuffix: formatMessage(messages.paginationPerPage),
+                  }}
                 />
               </form>
               {inputs.inputFilters !== undefined && inputs.inputFilters.value.length > 0 && (


### PR DESCRIPTION
The patternfly pagination component allows us to set some of the strings manually. The items per page string is now translated. 

This fixes some of the issues in #1084 