### PR TITLE
wizard: refactor image step

### DIFF
--- a/components/Wizard/CreateImageUpload.js
+++ b/components/Wizard/CreateImageUpload.js
@@ -73,6 +73,7 @@ class CreateImageUploadModal extends React.Component {
     this.getDefaultImageSize = this.getDefaultImageSize.bind(this);
     this.isPendingChange = this.isPendingChange.bind(this);
     this.isValidImageSize = this.isValidImageSize.bind(this);
+    this.isValidOstreeRef = this.isValidOstreeRef.bind(this);
     this.requiresImageSize = this.requiresImageSize.bind(this);
     this.missingRequiredFields = this.missingRequiredFields.bind(this);
     this.setNotifications = this.setNotifications.bind(this);
@@ -242,7 +243,7 @@ class CreateImageUploadModal extends React.Component {
 
   setImageSize(value) {
     this.setState({
-      imageSize: value ? Number(value) : undefined,
+      imageSize: value || undefined,
     });
   }
 
@@ -271,15 +272,14 @@ class CreateImageUploadModal extends React.Component {
   }
 
   disableCreateButton(activeStepName) {
-    if (this.state.imageType === "") {
-      return true;
-    }
+    if (this.state.imageType === "") return true;
     if (
       this.requiresImageSize(this.state.imageType) &&
       (this.state.imageSize === undefined || (!this.isValidImageSize() && this.state.uploadService === ""))
     ) {
       return true;
     }
+    if (!this.isValidOstreeRef(this.state.ostreeSettings.ref)) return true;
     if (this.missingRequiredFields() && activeStepName === "Review") {
       return true;
     }
@@ -298,7 +298,7 @@ class CreateImageUploadModal extends React.Component {
   }
 
   requiresImageSize(imageType) {
-    if (imageType === "fedora-iot-commit" || imageType === "rhel-edge-commit") {
+    if (imageType === "" || imageType === "fedora-iot-commit" || imageType === "rhel-edge-commit") {
       return false;
     }
     return true;
@@ -317,6 +317,13 @@ class CreateImageUploadModal extends React.Component {
     return true;
   }
 
+  isValidOstreeRef(ref) {
+    // eslint-disable-next-line max-len
+    // This regex is based on https://github.com/ostreedev/ostree/blob/73742252e286e8b53677555dc1b0d52d55fb7012/src/libostree/ostree-core.c#L151
+    const refValidationRegex = /^(?:[\w\d][-._\w\d]*\/)*[\w\d][-._\w\d]*$/;
+    return ref === "" || refValidationRegex.test(ref);
+  }
+
   render() {
     const { formatMessage } = this.props.intl;
     const { showUploadAwsStep, showUploadAzureStep, showReviewStep, uploadService } = this.state;
@@ -331,8 +338,8 @@ class CreateImageUploadModal extends React.Component {
           imageSize={this.state.imageSize}
           imageType={this.state.imageType}
           imageTypes={this.props.imageTypes}
+          isValidOstreeRef={this.isValidOstreeRef}
           isPendingChange={this.isPendingChange}
-          isValidImageSize={this.isValidImageSize}
           minImageSize={this.state.minImageSize}
           maxImageSize={this.state.maxImageSize}
           ostreeSettings={this.state.ostreeSettings}

--- a/public/custom.css
+++ b/public/custom.css
@@ -701,6 +701,7 @@ body {
 /* form group checkbox alignment fix */
 .pf-c-form__horizontal-group .pf-c-check,
 .pf-c-form__horizontal-group .pf-c-radio,
+.pf-c-form__group-control .pf-c-check,
 .cc-c-form__static-text {
   padding-top: var(--pf-global--spacer--form-element);
   padding-bottom: var(--pf-global--spacer--form-element);
@@ -727,21 +728,11 @@ body {
   justify-content: space-between;
 }
 
-.cc-c-form__horizontal-align {
-  align-items: baseline;
-}
-
 .cc-c-form__required-text {
   margin-bottom: var(--pf-global--gutter);
 }
 
-.cc-c-text__warning-icon {
-  color: var(--pf-global--warning-color--100);
-  vertical-align: -0.125em;
-}
-
-.cc-c-text__danger-icon {
-  color: var(--pf-global--danger-color--100);
+.cc-c-text__align-icon {
   vertical-align: -0.125em;
 }
 

--- a/test/verify/check-image
+++ b/test/verify/check-image
@@ -47,21 +47,28 @@ class TestImage(composerlib.ComposerCase):
         b.wait_not_present(".pf-c-popover__body")
         # groups action done
         b.wait_text("#continue-button", "Create")
-
+        # check ? (image size help) button
+        b.click("button[aria-label='Image size help']")
+        b.wait_text(".pf-c-popover__body",
+                    "Set the size that you want the image to be when instantiated. The total "
+                    "package size and target destination of your image should be considered when "
+                    "setting the image size.")
+        b.click(".pf-c-popover__content button")
+        b.wait_not_present(".pf-c-popover__body")
         # default size = 2GB for qcow2 image
-        b.wait_val("#create-image-size", 2)
-        b.focus("#create-image-size")
+        b.wait_val("#image-size-input", 2)
+        b.focus("#image-size-input")
         # delete 2 and input 1
         b.key_press("\b")
         b.key_press("1")
         # error if less than 2 GB
         b.wait_attr("#create-image-upload-wizard button:contains('Create')", "disabled", "")
-        b.wait_attr_contains("#help-text-simple-form-name-helper", "class", "pf-m-error")
+        b.wait_attr_contains("#image-size-input-helper", "class", "pf-m-error")
         # delete 1 and input 2001
         b.key_press("\b")
         b.key_press("2001")
         # error if greater than 2000 GB
-        b.wait_in_text("#help-text-simple-form-name-helper",
+        b.wait_in_text("#image-size-input-helper",
                        "The size specified is large. We recommend that you check whether your "
                        "target destination has any restrictions on image size.")
         # delete 2001 and input 2
@@ -99,7 +106,7 @@ class TestImage(composerlib.ComposerCase):
         # still keep Create if upload image not selected
         b.wait_text("#continue-button", "Create")
         # default size = 6GB for ami image
-        b.wait_val("#create-image-size", 6)
+        b.wait_val("#image-size-input", 6)
         # check ? (AWS upload image help) button
         b.click("button[aria-label='Upload image help']")
         b.wait_in_text(".pf-c-popover__body",
@@ -240,7 +247,7 @@ class TestImage(composerlib.ComposerCase):
         # still keep Create if upload image not selected
         b.wait_text("#continue-button", "Create")
         # default size = 6GB for azure vhd images
-        b.wait_val("#create-image-size", 2)
+        b.wait_val("#image-size-input", 2)
         # check ? (Azure upload image help) button
         b.click("button[aria-label='Upload image help']")
         print(b.text(".pf-c-popover__body"))
@@ -350,7 +357,7 @@ class TestImage(composerlib.ComposerCase):
         b.set_val("#image-type", value_id)
         b.wait_val("#image-type", value_id)
         # group actions end
-        b.focus("#create-image-size")
+        b.focus("#image-size-input")
         # delete 2 and input 4
         b.key_press("\b")
         b.key_press("4")


### PR DESCRIPTION
The image step now primarily uses pf4 react components instead of html elements with pf4 styles applied. This includes several minor improvements.

Field validation is improved. The image size field's validation style has been improved to include success and error colors and icons. The ostree ref is now validated to make sure the format of the ref won't error during the build process.

Image type is now marked as a required field. The help icons are formatted to be in line with text. The image size field is not required for all image types so it is now only displayed after selecting image type.

All changes follow patternfly's [form style guide](https://www.patternfly.org/v4/design-guidelines/usage-and-behavior/forms)

Fixes #1011 