### PR TITLE
utils: remove fedora 33 cockpituous release

### DIFF
--- a/utils/cockpituous-release
+++ b/utils/cockpituous-release
@@ -19,7 +19,6 @@ job release-srpm -V
 job release-koji master
 job release-koji f31
 job release-koji f32
-job release-koji f33
 
 job release-github
 job release-copr @osbuild/cockpit-composer
@@ -27,4 +26,3 @@ job release-copr @osbuild/cockpit-composer
 # Create a Bodhi update for stable Fedora releases
 job release-bodhi F31
 job release-bodhi F32
-job release-bodhi F33


### PR DESCRIPTION
Fedora 33 is not currently supported by osbuild-composer so cockpit-composer should not release into fedora 33 until support is
added.