### PR TITLE
tests: Update to new testlib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ machine: bots
 # checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
 # this needs a recent adjustment for firefox 77 and working with network-enabled tests
 test/common:
-	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 225
+	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 228
 	git checkout --force FETCH_HEAD -- test/common
 	git reset test/common
 

--- a/test/verify/check-blueprint
+++ b/test/verify/check-blueprint
@@ -17,7 +17,7 @@ class TestBlueprint(composerlib.ComposerCase):
     def testCreate(self):
         b = self.browser
 
-        self.login_and_go("/composer", authorized=True)
+        self.login_and_go("/composer", superuser=True)
         b.wait_present("#main")
 
         # create blueprint
@@ -81,7 +81,7 @@ class TestBlueprint(composerlib.ComposerCase):
     def testFilter(self):
         b = self.browser
 
-        self.login_and_go("/composer", authorized=True)
+        self.login_and_go("/composer", superuser=True)
         b.wait_present("#main")
 
         # filter "openssh-server" blueprint
@@ -112,7 +112,7 @@ class TestBlueprint(composerlib.ComposerCase):
     def testSort(self):
         b = self.browser
 
-        self.login_and_go("/composer", authorized=True)
+        self.login_and_go("/composer", superuser=True)
         b.wait_present("#main")
 
         blueprint_list = [
@@ -141,7 +141,7 @@ class TestBlueprint(composerlib.ComposerCase):
         b = self.browser
         m = self.machine
 
-        self.login_and_go("/composer", authorized=True)
+        self.login_and_go("/composer", superuser=True)
         b.wait_present("#main")
 
         # export package list

--- a/test/verify/check-custom
+++ b/test/verify/check-custom
@@ -20,7 +20,7 @@ class TestCustom(composerlib.ComposerCase):
         b = self.browser
         m = self.machine
 
-        self.login_and_go("/composer", authorized=True)
+        self.login_and_go("/composer", superuser=True)
         b.wait_present("#main")
 
         # go to blueprint openssh-server
@@ -63,7 +63,7 @@ class TestCustom(composerlib.ComposerCase):
         b = self.browser
         m = self.machine
 
-        self.login_and_go("/composer", authorized=True)
+        self.login_and_go("/composer", superuser=True)
         b.wait_present("#main")
 
         # go to blueprint openssh-server
@@ -103,7 +103,7 @@ class TestCustom(composerlib.ComposerCase):
         b = self.browser
         m = self.machine
 
-        self.login_and_go("/composer", authorized=True)
+        self.login_and_go("/composer", superuser=True)
         b.wait_present("#main")
 
         b.click("#openssh-server-name")
@@ -160,7 +160,7 @@ class TestCustom(composerlib.ComposerCase):
                     b.focus(sel)
                     b.key_press(k)
 
-        self.login_and_go("/composer", authorized=True)
+        self.login_and_go("/composer", superuser=True)
         b.wait_present("#main")
 
         b.click("#openssh-server-name")

--- a/test/verify/check-dependence
+++ b/test/verify/check-dependence
@@ -14,7 +14,7 @@ class TestDependence(composerlib.ComposerCase):
     def testComponent(self):
         b = self.browser
 
-        self.login_and_go("/composer", authorized=True)
+        self.login_and_go("/composer", superuser=True)
         b.wait_present("#main")
 
         # go to edit package page
@@ -48,7 +48,7 @@ class TestDependence(composerlib.ComposerCase):
     def testDetails(self):
         b = self.browser
 
-        self.login_and_go("/composer", authorized=True)
+        self.login_and_go("/composer", superuser=True)
         b.wait_present("#main")
 
         # go to edit package page

--- a/test/verify/check-image
+++ b/test/verify/check-image
@@ -16,7 +16,7 @@ class TestImage(composerlib.ComposerCase):
     def testImageStep(self):
         b = self.browser
 
-        self.login_and_go("/composer", authorized=True)
+        self.login_and_go("/composer", superuser=True)
         b.wait_present("#main")
 
         # create image wizard (no upload support)
@@ -82,7 +82,7 @@ class TestImage(composerlib.ComposerCase):
     def testAWSStep(self):
         b = self.browser
 
-        self.login_and_go("/composer", authorized=True)
+        self.login_and_go("/composer", superuser=True)
         b.wait_present("#main")
 
         # create image wizard
@@ -223,7 +223,7 @@ class TestImage(composerlib.ComposerCase):
     def testAzureStep(self):
         b = self.browser
 
-        self.login_and_go("/composer", authorized=True)
+        self.login_and_go("/composer", superuser=True)
         b.wait_present("#main")
 
         # create image wizard
@@ -335,7 +335,7 @@ class TestImage(composerlib.ComposerCase):
         b = self.browser
         m = self.machine
 
-        self.login_and_go("/composer", authorized=True)
+        self.login_and_go("/composer", superuser=True)
         b.wait_present("#main")
 
         # create image wizard
@@ -432,7 +432,7 @@ class TestImage(composerlib.ComposerCase):
         elif (os.environ.get("TEST_OS") == "rhel-8-3"):
             image_type_ostree = "rhel-edge-commit"
 
-        self.login_and_go("/composer", authorized=True)
+        self.login_and_go("/composer", superuser=True)
         b.wait_present("#main")
 
         # create image wizard
@@ -508,7 +508,7 @@ class TestImage(composerlib.ComposerCase):
         b = self.browser
         m = self.machine
 
-        self.login_and_go("/composer", authorized=True)
+        self.login_and_go("/composer", superuser=True)
         b.wait_present("#main")
 
         # create image wizard

--- a/test/verify/check-package
+++ b/test/verify/check-package
@@ -16,7 +16,7 @@ class TestPackage(composerlib.ComposerCase):
     def testNavigate(self):
         b = self.browser
 
-        self.login_and_go("/composer", authorized=True)
+        self.login_and_go("/composer", superuser=True)
         b.wait_present("#main")
 
         # go to edit package page
@@ -79,7 +79,7 @@ class TestPackage(composerlib.ComposerCase):
     def testSort(self):
         b = self.browser
 
-        self.login_and_go("/composer", authorized=True)
+        self.login_and_go("/composer", superuser=True)
         b.wait_present("#main")
 
         # go to edit package page
@@ -113,7 +113,7 @@ class TestPackage(composerlib.ComposerCase):
     def testRedoUndoCommit(self):
         b = self.browser
 
-        self.login_and_go("/composer", authorized=True)
+        self.login_and_go("/composer", superuser=True)
         b.wait_present("#main")
 
         # go to edit package page
@@ -163,7 +163,7 @@ class TestPackage(composerlib.ComposerCase):
 
         # logout and login, still in edit blueprint page
         with b.wait_timeout(300):
-            b.relogin("/composer", authorized=True)
+            b.relogin("/composer", superuser=True)
         b.wait_present("ul[aria-label='Available Components'] li:nth-child(1)")
 
         # "1 Pending Change" still there
@@ -200,7 +200,7 @@ class TestPackage(composerlib.ComposerCase):
     def testDiscard(self):
         b = self.browser
 
-        self.login_and_go("/composer", authorized=True)
+        self.login_and_go("/composer", superuser=True)
         b.wait_present("#main")
 
         # go to edit package page

--- a/test/verify/check-service
+++ b/test/verify/check-service
@@ -29,7 +29,7 @@ class TestService(composerlib.ComposerCase):
     def testBasic(self):
         b = self.browser
 
-        self.login_and_go("/composer", authorized=True)
+        self.login_and_go("/composer", superuser=True)
         b.wait_present("#main")
 
         # start and enable osbuild-composer from UI
@@ -114,7 +114,7 @@ class TestService(composerlib.ComposerCase):
         # stop and disable osbuild-composer.socket
         m.execute("systemctl disable --now osbuild-composer.socket")
 
-        self.login_and_go("/composer", authorized=True)
+        self.login_and_go("/composer", superuser=True)
         b.wait_present("#main")
 
         # do not enable osbuild-composer
@@ -141,7 +141,7 @@ class TestService(composerlib.ComposerCase):
         # stop and disable osbuild-composer.socket
         m.execute("systemctl disable --now osbuild-composer.socket")
 
-        self.login_and_go("/composer", authorized=False)
+        self.login_and_go("/composer", superuser=False)
         b.wait_present("#main")
 
         # Start button can be disabled button or clickable button

--- a/test/verify/check-source
+++ b/test/verify/check-source
@@ -20,7 +20,7 @@ class TestSource(composerlib.ComposerCase):
             "/xiaofwan/sway-copr/fedora-31-x86_64"
         repo_name = "sway-copr"
 
-        self.login_and_go("/composer", authorized=True)
+        self.login_and_go("/composer", superuser=True)
         b.wait_present("#main")
 
         # open manage sources dialog


### PR DESCRIPTION
Since Cockpit version 228 we don't have anymore that 'Reuse my password'
checkbox on the login page. But old testlib (functions like `login_and_go()`)
try to use this checkbox. Therefore we need to use newer library.

Also `authorized` was replaced by `superuser`.

See https://github.com/cockpit-project/cockpit/commit/ef97e7e9a28a