### PR TITLE
pages: fix blueprints page error state

### DIFF
--- a/core/store.js
+++ b/core/store.js
@@ -33,7 +33,7 @@ const initialState = {
   blueprints: {
     blueprintList: [],
     fetchingBlueprints: true,
-    errorState: null,
+    errorState: undefined,
   },
   composes: {
     composeTypes: [],

--- a/pages/blueprints/index.js
+++ b/pages/blueprints/index.js
@@ -95,8 +95,11 @@ class BlueprintsPage extends React.Component {
           manageSources={manageSources}
         />
         {(blueprintsLoading === true && <Loading />) ||
+          (blueprintsError === undefined && (
+            <EmptyStateInactive fetchingBlueprints={this.props.fetchingBlueprints} />
+          )) ||
           (blueprintsError !== null &&
-            ((blueprintsError.message === "not-found" && (
+            (((blueprintsError.problem === "access-denied" || blueprintsError.message === "not-found") && (
               <EmptyStateInactive fetchingBlueprints={this.props.fetchingBlueprints} />
             )) || (
               <EmptyState

--- a/test/verify/check-service
+++ b/test/verify/check-service
@@ -154,7 +154,8 @@ class TestService(composerlib.ComposerCase):
         #     b.wait_in_text(".cmpsr-alert-blank-slate", "Not permitted to perform this action.")
         #     # Start button still there
         #     b.wait_visible("button:contains('Start')")
-
+        # We expect multiple permission denied journal messages from the api calls
+        self.allow_journal_messages(".*: couldn't connect: Permission denied")
         # collect code coverage result
         self.check_coverage()
 


### PR DESCRIPTION
When a user enters the blueprints page and osbuild-composer is not running they are prompted to start the socket. This same error state displays if the user is not root but the button to start the socket is disabled and alerts the user they don't have permissions. The check-service test is updated to accept the log messages associated with trying to access the api without root privileges.