### PR TITLE
better error message

### DIFF
--- a/core/composer.js
+++ b/core/composer.js
@@ -36,13 +36,24 @@ function request(options) {
         else if (replyFormat === "raw") resolve(data);
         else throw new Error(`invalid replyFormat: '${replyFormat}'`);
       })
-      .catch((error) =>
+      .catch((error, data) => {
+        /*
+         * osbuild-composer describes the error in more detail, so add the body
+         * so it at least can be logged for more information.
+         */
+        let body = data;
+        try {
+          body = JSON.parse(body);
+        } catch {
+          /* just keep the data as string */
+        }
         reject({
           problem: error.problem,
           message: error.message,
           options,
-        })
-      );
+          body,
+        });
+      });
   });
 }
 

--- a/rpmversion.sh
+++ b/rpmversion.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Generate the version and release strings to use in the spec file.
 # The output of this script is "<VERSION>-<RELEASE>",


### PR DESCRIPTION
osbuild-composer often specifies more detailed errors in the body of the response, so also log that, and try to parse it as json.

![Screenshot from 2020-09-28 10-50-51](https://user-images.githubusercontent.com/11140201/94411388-cd7a9c00-0178-11eb-8443-a6a7cf937fff.png)

---

the bash arithmetic commit was a requirement to get cockpit-composer to make rpms on debian, also `--nodeps` for rpmbuild was required but it wouldn't be a good idea to commit that :)