### PR TITLE
test: Use the @noretry decorator for check-image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ machine: bots
 # checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
 # this needs a recent adjustment for firefox 77 and working with network-enabled tests
 test/common:
-	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 228
+	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 229
 	git checkout --force FETCH_HEAD -- test/common
 	git reset test/common
 

--- a/test/verify/check-image
+++ b/test/verify/check-image
@@ -11,6 +11,7 @@ import testlib
 
 @testlib.nondestructive
 @testlib.timeout(2400)
+@testlib.noretry
 class TestImage(composerlib.ComposerCase):
 
     def testImageStep(self):


### PR DESCRIPTION
This is blocked on https://github.com/cockpit-project/cockpit/pull/14680