### PR TITLE
cockpituous: Run release in a GitHub workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: release
+on:
+  push:
+    tags:
+      # this is a glob, not a regexp
+      - '[0-9]*'
+jobs:
+  cockpituous:
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/cockpit/release
+    steps:
+      - name: Set up configuration and secrets
+        run: |
+          # override GitHub's bind mount from host, we don't want anything from there and it interferes with ssh
+          export HOME=$(getent passwd $(id -u) | cut -f6 -d:)
+
+          echo '${{ secrets.SSH_KNOWN_HOSTS }}' > ~/.ssh/known_hosts
+          echo '${{ secrets.FEDPKG_SSH_PUBLIC }}' > ~/.ssh/id_rsa.pub
+          echo '${{ secrets.FEDPKG_SSH_PRIVATE }}' > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          echo 'cockpit' > ~/.config/bodhi-user
+          echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/github-token
+          echo '${{ secrets.COPR_TOKEN }}' > ~/.config/copr
+          echo '${{ secrets.COCKPIT_FEDORA_PASSWORD }}' > ~/.fedora-password
+
+      - name: Run cockpituous
+        run: |
+          # override GitHub's bind mount from host, we don't want anything from there and it interferes with ssh
+          export HOME=$(getent passwd $(id -u) | cut -f6 -d:)
+          cd /build
+          release-runner -r https://github.com/$GITHUB_REPOSITORY -t $(basename $GITHUB_REF) utils/cockpituous-release

--- a/README.md
+++ b/README.md
@@ -214,9 +214,12 @@ When the project is ready for a new release, do the following:
 
 (an editor should open automatically, and gpg is required to be setup in order to sign the tag).
 
-Then push the tag with `git push --tags`. This will trigger
-[cockpituous](https://github.com/cockpit-project/cockpituous/tree/master/release)
-to build a new release of cockpit-composer.
+Then push the tag with `git push --tags`. This triggers the [release.yml](.github/workflows/release.yml)
+[GitHub action](https://github.com/features/actions) workflow.
+
+The workflow runs [cockpituous](https://github.com/cockpit-project/cockpituous/tree/master/release)
+to build a new release of cockpit-composer, with the [cockpituous-release](./utils/cockpituous-release) control file.
+This uses the shared [cockpit-project organization secrets](https://github.com/organizations/cockpit-project/settings/secrets).
 
 Finally, import the new `.srpm` into the appropriate RHEL release.
 


### PR DESCRIPTION
Enter the new world of GitHub actions [1]/GitLab pipelines [2]. This
simplifies our end of the infrastructure considerably:

* No need any more to set up webhooks, all the relevant configuration
  is right in the workflow file.

* Does not need any infrastructure on our side any more.

* GitHub automatically provides a temporary `GITHUB_TOKEN` with
  sufficient write access to the project to publish a release, so we
  don't need to carry around that secret.

[1] https://github.com/features/actions
[2] https://docs.gitlab.com/ee/ci/pipelines/

 - [x] When landing, disable the "repo/tag creation" webhook