### PR TITLE
test: add rhel 8.4 ostree test

### DIFF
--- a/test/verify/check-image
+++ b/test/verify/check-image
@@ -431,7 +431,7 @@ class TestImage(composerlib.ComposerCase):
         distro = os.environ.get("TEST_OS")
         if (distro == "fedora-32" or distro == "fedora-33"):
             image_type_ostree = "fedora-iot-commit"
-        elif (distro == "rhel-8-3"):
+        elif (distro == "rhel-8-3" or distro == "rhel-8-4"):
             image_type_ostree = "rhel-edge-commit"
 
         self.login_and_go("/composer", superuser=True)


### PR DESCRIPTION
When checking for which image type the ostree should be, rhel 8.4 is now supported for a rhel-edge-commit.

I believe this will fix our rhel 8.4 tests. Currently an error will get thrown in a rhel 8.4 machine when trying to build an ostree image because `image_type_ostree = "rhel-edge-commit"` is not set and therefore the image type can not be found. However, I am not 100% confident this will fix the issue since the logs state the image is failing with the call:
```
-> wait: ph_is_visible("#image-type")
<- {'type': 'undefined'}
```

This would lead me to assume the tests cannot find the image-type select menu. But, the image-type selector wait occurs directly before the call for using the `image_type_ostree` variable. And, since this variable needs to be set anyway, this change is required to get the rhel 8.4 tests passing. 

Also, @henrywang do you have a suggestion for a better way to break if the distro is not one we explicitely declare in this if else statement?