### PR TITLE
components: remove shortid

### DIFF
--- a/components/ListView/ComponentInputs.js
+++ b/components/ListView/ComponentInputs.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { defineMessages, injectIntl, intlShape } from "react-intl";
 import PropTypes from "prop-types";
-import shortid from "shortid";
 import {
   DataList,
   DataListItem,
@@ -38,7 +37,7 @@ class ComponentInputs extends React.Component {
       <DataList aria-label={label} data-list="inputs" className="cc-m-compact">
         {components.map((component) => (
           <DataListItem
-            key={shortid.generate()}
+            key={component.name}
             aria-labelledby={`${component.name}-input`}
             className={component.active ? "active" : ""}
             data-input={component.name}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "redux-saga": "0.15.6",
     "regenerator-runtime": "0.13.7",
     "reselect": "3.0.1",
-    "shortid": "2.2.15",
     "whatwg-fetch": "1.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The short id package is only used for a key value and is not needed. Instead the component name is now used for the key. The component names will always be unique so they will work as a key.