### PR TITLE
package.json: update @patternfly/react-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@patternfly/patternfly": "4.50.4",
-    "@patternfly/react-core": "4.75.2",
+    "@patternfly/react-core": "4.79.2",
     "@patternfly/react-icons": "4.7.16",
     "@patternfly/react-table": "4.19.5",
     "bootstrap": "3.4.1",


### PR DESCRIPTION
@patternfly/react-core 4.75.2 broke our builds due to a missing style for the Splitter component. Upgrading to 4.79.2 fixes the error.