### PR TITLE
Disable local worker socket in tests

### DIFF
--- a/test/verify/check-service
+++ b/test/verify/check-service
@@ -23,7 +23,7 @@ class TestService(composerlib.ComposerCase):
             for bp in $(composer-cli blueprints list); do
                 composer-cli blueprints delete $bp
             done
-            systemctl disable --now osbuild-composer.socket
+            systemctl disable --now osbuild-composer.socket osbuild-composer.service
         """)
 
     def testBasic(self):
@@ -112,7 +112,7 @@ class TestService(composerlib.ComposerCase):
         m = self.machine
 
         # stop and disable osbuild-composer.socket
-        m.execute("systemctl disable --now osbuild-composer.socket")
+        m.execute("systemctl disable --now osbuild-composer.socket osbuild-composer.service")
 
         self.login_and_go("/composer", superuser=True)
         b.wait_present("#main")
@@ -139,7 +139,7 @@ class TestService(composerlib.ComposerCase):
         m = self.machine
 
         # stop and disable osbuild-composer.socket
-        m.execute("systemctl disable --now osbuild-composer.socket")
+        m.execute("systemctl disable --now osbuild-composer.socket osbuild-composer.service")
 
         self.login_and_go("/composer", superuser=False)
         b.wait_present("#main")

--- a/test/verify/check-service
+++ b/test/verify/check-service
@@ -23,7 +23,7 @@ class TestService(composerlib.ComposerCase):
             for bp in $(composer-cli blueprints list); do
                 composer-cli blueprints delete $bp
             done
-            systemctl disable --now osbuild-composer.socket osbuild-composer.service
+            systemctl disable --now osbuild-composer.socket osbuild-local-worker.socket osbuild-composer.service
         """)
 
     def testBasic(self):
@@ -112,7 +112,7 @@ class TestService(composerlib.ComposerCase):
         m = self.machine
 
         # stop and disable osbuild-composer.socket
-        m.execute("systemctl disable --now osbuild-composer.socket osbuild-composer.service")
+        m.execute("systemctl disable --now osbuild-composer.socket osbuild-local-worker.socket osbuild-composer.service")
 
         self.login_and_go("/composer", superuser=True)
         b.wait_present("#main")
@@ -139,7 +139,7 @@ class TestService(composerlib.ComposerCase):
         m = self.machine
 
         # stop and disable osbuild-composer.socket
-        m.execute("systemctl disable --now osbuild-composer.socket osbuild-composer.service")
+        m.execute("systemctl disable --now osbuild-composer.socket osbuild-local-worker.socket osbuild-composer.service")
 
         self.login_and_go("/composer", superuser=False)
         b.wait_present("#main")

--- a/test/verify/composerlib.py
+++ b/test/verify/composerlib.py
@@ -35,7 +35,7 @@ class ComposerCase(testlib.MachineCase):
 
         # re-start osbuild-composer.socket
         self.machine.execute(script="""#!/bin/sh
-        systemctl stop --quiet osbuild-composer.socket osbuild-composer.service
+        systemctl stop --quiet osbuild-composer.socket osbuild-local-worker.socket osbuild-composer.service
         systemctl start osbuild-composer.socket
         """)
 

--- a/test/verify/composerlib.py
+++ b/test/verify/composerlib.py
@@ -35,7 +35,8 @@ class ComposerCase(testlib.MachineCase):
 
         # re-start osbuild-composer.socket
         self.machine.execute(script="""#!/bin/sh
-        systemctl stop --quiet osbuild-composer.socket && systemctl start osbuild-composer.socket
+        systemctl stop --quiet osbuild-composer.socket osbuild-composer.service
+        systemctl start osbuild-composer.socket
         """)
 
         # push pre-defined blueprint


### PR DESCRIPTION
This work is based upon #1183. I am unable to replicate the test failures locally so I am opening this draft PR to test this change.