### PR TITLE
test: fix TestSource modal reload issue

### DIFF
--- a/test/verify/check-source
+++ b/test/verify/check-source
@@ -57,16 +57,13 @@ class TestSource(composerlib.ComposerCase):
         b.set_val(dropdown_menu_sel, value_id)
         b.wait_val(dropdown_menu_sel, value_id)
         # groups action done
-        b.wait_present("button:contains('Add Source')")
         b.click("button:contains('Add Source')")
 
         # HACK: workaround issue https://github.com/osbuild/cockpit-composer/issues/989
         # open manage source again to continue running test
         if b.cdp.browser == "firefox":
             # open manage sources dialog
-            drop_down_sel = ".toolbar-pf-action-right #dropdownKebab"
-            b.wait_present("#main")
-            b.wait_attr(drop_down_sel, "aria-expanded", "false")
+            b.wait_not_present("#cmpsr-modal-manage-sources")
             b.click(drop_down_sel)
             b.wait_attr(drop_down_sel, "aria-expanded", "true")
             b.click("a:contains('Manage Sources')")


### PR DESCRIPTION
In the firefox nightlies the add source modal will drop after adding a new source. In order to continue the tests we need to reopen it. We now wait until the modal has closed before we reopen it.