### PR TITLE
test: update README

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -55,7 +55,7 @@ interactively follow what a test is doing, set environment variable `$TEST_SHOW_
 You can set these environment variables to configure the test suite:
 
     TEST_OS    The OS to run the tests in.  Currently supported values:
-                  "fedora-32"
+                  "fedora-32, fedora-33, rhel-8-4"
                "fedora-32" is the default
 
     TEST_DATA  Where to find and store test machine images.  The


### PR DESCRIPTION
With the incoming support for rhel-8-4 the testing README now contains the test distros we actively test on.