### PR TITLE
test: fix call to stop osbuild-local-worker.socket

### DIFF
--- a/test/verify/composerlib.py
+++ b/test/verify/composerlib.py
@@ -38,7 +38,7 @@ class ComposerCase(testlib.MachineCase):
 
         # re-start osbuild-composer.socket
         self.machine.execute(script="""#!/bin/sh
-        systemctl stop --quiet osbuild-composer.socket osbuild-local-worker.socket osbuild-composer.service
+        systemctl stop --quiet osbuild-composer.socket osbuild-composer.service
         systemctl start osbuild-composer.socket
         """)
         if (distro == "fedora-32" or distro == "fedora-33"):


### PR DESCRIPTION
The test setup should only stop the osbuild-local-worker socket if the distro is fedora 32 or 33.