### PR TITLE
tests: Always check if elements are visible

### DIFF
--- a/test/verify/check-blueprint
+++ b/test/verify/check-blueprint
@@ -18,11 +18,11 @@ class TestBlueprint(composerlib.ComposerCase):
         b = self.browser
 
         self.login_and_go("/composer", superuser=True)
-        b.wait_present("#main")
+        b.wait_visible("#main")
 
         # create blueprint
         b.click(".toolbar-pf-action-right #cmpsr-btn-crt-blueprint")
-        b.wait_present("div[role=dialog] #cmpsr-modal-crt-blueprint")
+        b.wait_visible("div[role=dialog] #cmpsr-modal-crt-blueprint")
         # empty name blueprint
         b.set_input_text("#textInput-modal-markup", "")
         b.set_input_text("#textInput2-modal-markup", "test")
@@ -42,7 +42,7 @@ class TestBlueprint(composerlib.ComposerCase):
         }
         for c in invalid_chars.keys():
             b.click(".toolbar-pf-action-right #cmpsr-btn-crt-blueprint")
-            b.wait_present("div[role=dialog] #cmpsr-modal-crt-blueprint")
+            b.wait_visible("div[role=dialog] #cmpsr-modal-crt-blueprint")
             # empty name blueprint
             b.set_input_text("#textInput-modal-markup", "-_.{}".format(c))
             b.wait_text("#cmpsr-modal-crt-blueprint .help-block",
@@ -54,7 +54,7 @@ class TestBlueprint(composerlib.ComposerCase):
         # wait until the openssh-server blueprint is there
         b.wait_in_text("ul[aria-label=Blueprints]", "openssh-server")
         b.click(".toolbar-pf-action-right #cmpsr-btn-crt-blueprint")
-        b.wait_present("div[role=dialog] #cmpsr-modal-crt-blueprint")
+        b.wait_visible("div[role=dialog] #cmpsr-modal-crt-blueprint")
         # empty name blueprint
         b.set_input_text("#textInput-modal-markup", "openssh-server")
         b.set_input_text("#textInput2-modal-markup", "openssh server image")
@@ -67,7 +67,7 @@ class TestBlueprint(composerlib.ComposerCase):
         # wait until the openssh-server blueprint is there
         b.wait_in_text("ul[aria-label=Blueprints]", "openssh-server")
         b.click(".toolbar-pf-action-right #cmpsr-btn-crt-blueprint")
-        b.wait_present("div[role=dialog] #cmpsr-modal-crt-blueprint")
+        b.wait_visible("div[role=dialog] #cmpsr-modal-crt-blueprint")
         # empty name blueprint
         b.set_input_text("#textInput-modal-markup", "openssh-server")
         b.key_press("\r")
@@ -82,13 +82,13 @@ class TestBlueprint(composerlib.ComposerCase):
         b = self.browser
 
         self.login_and_go("/composer", superuser=True)
-        b.wait_present("#main")
+        b.wait_visible("#main")
 
         # filter "openssh-server" blueprint
         b.set_input_text("#filter-blueprints", "openssh")
         b.key_press("\r")
         b.wait_in_text(".filter-pf-active-label + .list-inline .label", "Name: openssh")
-        b.wait_present("#openssh-server-name")
+        b.wait_visible("#openssh-server-name")
         b.wait_not_present("#httpd-server-name")
         # clear filter
         b.click(".filter-pf-active-label + .list-inline .pficon-close")
@@ -99,9 +99,9 @@ class TestBlueprint(composerlib.ComposerCase):
         b.key_press("\r")
         b.wait_in_text(".filter-pf-active-label + .list-inline .label", "Name: httpd")
         b.wait_not_present("#openssh-server-name")
-        b.wait_present("#httpd-server-name")
-        b.wait_present("#httpd-server-with-hostname-name")
-        b.wait_present("#httpd-server-with-user-name")
+        b.wait_visible("#httpd-server-name")
+        b.wait_visible("#httpd-server-with-hostname-name")
+        b.wait_visible("#httpd-server-with-user-name")
         # clear filter
         b.click("button:contains('Clear All Filters')")
         b.wait_not_present("p:contains('Active Filters:')")
@@ -113,7 +113,7 @@ class TestBlueprint(composerlib.ComposerCase):
         b = self.browser
 
         self.login_and_go("/composer", superuser=True)
-        b.wait_present("#main")
+        b.wait_visible("#main")
 
         blueprint_list = [
             "httpd-server",
@@ -122,15 +122,15 @@ class TestBlueprint(composerlib.ComposerCase):
             "openssh-server"
         ]
         # sort from Z-A
-        b.wait_present("ul[aria-label=Blueprints]")
+        b.wait_visible("ul[aria-label=Blueprints]")
         b.click(".fa-sort-alpha-asc")
-        b.wait_present(".fa-sort-alpha-desc")
+        b.wait_visible(".fa-sort-alpha-desc")
         for i, v in enumerate(sorted(blueprint_list, reverse=True)):
             b.wait_text("ul[aria-label=Blueprints] li:nth-child({}) a strong".format(i + 1), v)
 
         # sort from A-Z
         b.click(".fa-sort-alpha-desc")
-        b.wait_present(".fa-sort-alpha-asc")
+        b.wait_visible(".fa-sort-alpha-asc")
         for i, v in enumerate(sorted(blueprint_list)):
             b.wait_text("ul[aria-label=Blueprints] li:nth-child({}) a strong".format(i + 1), v)
 
@@ -142,14 +142,14 @@ class TestBlueprint(composerlib.ComposerCase):
         m = self.machine
 
         self.login_and_go("/composer", superuser=True)
-        b.wait_present("#main")
+        b.wait_visible("#main")
 
         # export package list
         actions_drop_down_sel = "#openssh-server-kebab"
         b.click(actions_drop_down_sel)
         b.wait_attr(actions_drop_down_sel, "aria-expanded", "true")
         b.click("li[data-blueprint=openssh-server] a:contains('Export')")
-        b.wait_present("#cmpsr-modal-export")
+        b.wait_visible("#cmpsr-modal-export")
         with b.wait_timeout(300):
             b.wait_in_text("#textInput2-modal-markup", "openssh-server")
         packages_list = b.text("#textInput2-modal-markup")

--- a/test/verify/check-custom
+++ b/test/verify/check-custom
@@ -21,7 +21,7 @@ class TestCustom(composerlib.ComposerCase):
         m = self.machine
 
         self.login_and_go("/composer", superuser=True)
-        b.wait_present("#main")
+        b.wait_visible("#main")
 
         # go to blueprint openssh-server
         b.click("#openssh-server-name")
@@ -32,7 +32,7 @@ class TestCustom(composerlib.ComposerCase):
             b.click(actions_drop_down_sel)
         b.wait_attr(actions_drop_down_sel, "aria-expanded", "true")
         b.click("a:contains('Export')")
-        b.wait_present("#cmpsr-modal-export")
+        b.wait_visible("#cmpsr-modal-export")
         with b.wait_timeout(300):
             b.wait_in_text("#textInput2-modal-markup", "openssh-server")
         packages_list = b.text("#textInput2-modal-markup")
@@ -64,7 +64,7 @@ class TestCustom(composerlib.ComposerCase):
         m = self.machine
 
         self.login_and_go("/composer", superuser=True)
-        b.wait_present("#main")
+        b.wait_visible("#main")
 
         # go to blueprint openssh-server
         b.click("#openssh-server-name")
@@ -73,22 +73,22 @@ class TestCustom(composerlib.ComposerCase):
         updated_description = "edit ssh server image description"
         with b.wait_timeout(300):
             b.click("a:contains('ssh server image')")
-        b.wait_present("#cmpsr-modal-edit-description")
+        b.wait_visible("#cmpsr-modal-edit-description")
         b.set_input_text("#textInput-modal-markup", updated_description)
         b.click("#cmpsr-modal-edit-description button:contains('Cancel')")
         b.wait_not_present("#cmpsr-modal-edit-description")
-        b.wait_present("a:contains('ssh server image')")
+        b.wait_visible("a:contains('ssh server image')")
 
         # update description
         actions_drop_down_sel = ".cmpsr-header__actions #dropdownKebab"
         b.click(actions_drop_down_sel)
         b.wait_attr(actions_drop_down_sel, "aria-expanded", "true")
         b.click("a:contains('Edit description')")
-        b.wait_present("#cmpsr-modal-edit-description")
+        b.wait_visible("#cmpsr-modal-edit-description")
         b.set_input_text("#textInput-modal-markup", updated_description)
         b.click("#cmpsr-modal-edit-description button:contains('Save')")
         b.wait_not_present("#cmpsr-modal-edit-description")
-        b.wait_present("a:contains('{}')".format(updated_description))
+        b.wait_visible("a:contains('{}')".format(updated_description))
         # backend got updated as well
         desc = m.execute("""
             composer-cli blueprints show openssh-server | grep description | \
@@ -104,7 +104,7 @@ class TestCustom(composerlib.ComposerCase):
         m = self.machine
 
         self.login_and_go("/composer", superuser=True)
-        b.wait_present("#main")
+        b.wait_visible("#main")
 
         b.click("#openssh-server-name")
         with b.wait_timeout(300):
@@ -113,31 +113,31 @@ class TestCustom(composerlib.ComposerCase):
         b.click("button[aria-describedby=Hostname-help2]")
         b.set_input_text("input[aria-label=Hostname]", "hostname-openssh-server")
         b.click(".form-control-pf-save")
-        b.wait_present("span:contains(hostname-openssh-server)")
+        b.wait_visible("span:contains(hostname-openssh-server)")
         hostname = m.execute("""
             composer-cli blueprints show openssh-server | grep hostname | awk -F '"' '{print $2}'
             """).rstrip()
-        b.wait_present("span:contains({})".format(hostname))
+        b.wait_visible("span:contains({})".format(hostname))
 
         # update hostname
         b.click(".form-control-pf-value")
         b.set_input_text("input[aria-label=Hostname]", "update-openssh-server")
         b.key_press("\r")
-        b.wait_present("span:contains(update-openssh-server)")
+        b.wait_visible("span:contains(update-openssh-server)")
         hostname = m.execute("""
             composer-cli blueprints show openssh-server | grep hostname | awk -F '"' '{print $2}'
             """).rstrip()
-        b.wait_present("span:contains({})".format(hostname))
+        b.wait_visible("span:contains({})".format(hostname))
 
         # clicking x button will not update
         b.click(".form-control-pf-value")
         b.set_input_text("input[aria-label=Hostname]", "no-update-openssh-server")
         b.click(".form-control-pf-cancel")
-        b.wait_present("span:contains(update-openssh-server)")
+        b.wait_visible("span:contains(update-openssh-server)")
         hostname = m.execute("""
             composer-cli blueprints show openssh-server | grep hostname | awk -F '"' '{print $2}'
             """).rstrip()
-        b.wait_present("span:contains({})".format(hostname))
+        b.wait_visible("span:contains({})".format(hostname))
 
         # invalid character, save button is disabled
         b.click(".form-control-pf-value")
@@ -161,7 +161,7 @@ class TestCustom(composerlib.ComposerCase):
                     b.key_press(k)
 
         self.login_and_go("/composer", superuser=True)
-        b.wait_present("#main")
+        b.wait_visible("#main")
 
         b.click("#openssh-server-name")
         with b.wait_timeout(300):
@@ -169,7 +169,7 @@ class TestCustom(composerlib.ComposerCase):
 
         # add a new user
         b.click("button:contains('Create User Account')")
-        b.wait_present("#cmpsr-modal-user-account")
+        b.wait_visible("#cmpsr-modal-user-account")
         set_input_value("#textInput2-modal-user", "x y")
         b.wait_val("#textInput1-modal-user", "xy")
         b.click("input[type=checkbox]")
@@ -186,8 +186,8 @@ class TestCustom(composerlib.ComposerCase):
         b.wait_not_present("#cmpsr-modal-user-account")
         b.wait_text("tr td[data-label='Full name']", "x y")
         b.wait_text("tr td[data-label='User name']", "xy")
-        b.wait_present("tr td[data-label='Server administrator'] .fa-check")
-        b.wait_present("tr td[data-label=Password] .fa-check")
+        b.wait_visible("tr td[data-label='Server administrator'] .fa-check")
+        b.wait_visible("tr td[data-label=Password] .fa-check")
         b.wait_in_text("tr td[data-label='SSH key']", "cockpit-test")
 
         # check backend to have correct password configured
@@ -206,13 +206,13 @@ class TestCustom(composerlib.ComposerCase):
         # update password
         new_password = "c456rty$%^RTY"
         b.click("button[aria-label='Edit User Account xy']")
-        b.wait_present("#cmpsr-modal-user-account")
+        b.wait_visible("#cmpsr-modal-user-account")
         b.click("button:contains('Set New Password')")
         set_input_value("#textInput1-modal-password", new_password)
         set_input_value("#textInput2-modal-password", new_password)
         b.click("#cmpsr-modal-user-account button:contains('Update')")
         b.wait_not_present("#cmpsr-modal-user-account")
-        b.wait_present("tr td[data-label=Password] .fa-check")
+        b.wait_visible("tr td[data-label=Password] .fa-check")
         passwd_str = m.execute("""
             composer-cli blueprints show openssh-server | grep password | awk '{print $3}'
             """).strip('"\n')
@@ -222,16 +222,16 @@ class TestCustom(composerlib.ComposerCase):
 
         # remove password
         b.click("button[aria-label='Edit User Account xy']")
-        b.wait_present("#cmpsr-modal-user-account")
+        b.wait_visible("#cmpsr-modal-user-account")
         b.click("button:contains('Remove Password')")
         b.click("#cmpsr-modal-user-account button:contains('Update')")
         b.wait_not_present("#cmpsr-modal-user-account")
-        b.wait_present("tr td[data-label=Password]")
+        b.wait_visible("tr td[data-label=Password]")
         b.wait_not_present("tr td[data-label=Password] .fa-check")
 
         # duplicated user
         b.click("button:contains('Create User Account')")
-        b.wait_present("#cmpsr-modal-user-account")
+        b.wait_visible("#cmpsr-modal-user-account")
         set_input_value("#textInput2-modal-user", "x y")
         b.wait_val("#textInput1-modal-user", "xy")
         b.wait_in_text("#textInput1-modal-user-help1", "This user name already exists.")
@@ -240,7 +240,7 @@ class TestCustom(composerlib.ComposerCase):
 
         # password checking error
         b.click("button:contains('Create User Account')")
-        b.wait_present("#cmpsr-modal-user-account")
+        b.wait_visible("#cmpsr-modal-user-account")
         set_input_value("#textInput2-modal-user", "admin user")
         b.wait_val("#textInput1-modal-user", "auser")
         b.click("input[type=checkbox]")

--- a/test/verify/check-dependence
+++ b/test/verify/check-dependence
@@ -15,12 +15,12 @@ class TestDependence(composerlib.ComposerCase):
         b = self.browser
 
         self.login_and_go("/composer", superuser=True)
-        b.wait_present("#main")
+        b.wait_visible("#main")
 
         # go to edit package page
         b.click("li[data-blueprint=openssh-server] a:contains('Edit Packages')")
         with b.wait_timeout(120):
-            b.wait_present("ul[aria-label='Available Components'] li:nth-child(1)")
+            b.wait_visible("ul[aria-label='Available Components'] li:nth-child(1)")
 
         # open component detail
         b.click("#openssh-server-toggle")
@@ -29,7 +29,7 @@ class TestDependence(composerlib.ComposerCase):
         # https://github.com/osbuild/cockpit-composer/issues/942
         # # depsolving dependencies needs more time
         # with b.wait_timeout(480):
-        #     b.wait_present(".cc-component-summary__deps")
+        #     b.wait_visible(".cc-component-summary__deps")
         # # show all
         # b.click("button:contains('Show All')")
         # # show less
@@ -49,12 +49,12 @@ class TestDependence(composerlib.ComposerCase):
         b = self.browser
 
         self.login_and_go("/composer", superuser=True)
-        b.wait_present("#main")
+        b.wait_visible("#main")
 
         # go to edit package page
         b.click("li[data-blueprint=openssh-server] a:contains('Edit Packages')")
         with b.wait_timeout(120):
-            b.wait_present("ul[aria-label='Available Components'] li:nth-child(1)")
+            b.wait_visible("ul[aria-label='Available Components'] li:nth-child(1)")
 
         # view openssh-server package detail
         b.click("#openssh-server-kebab")
@@ -65,7 +65,7 @@ class TestDependence(composerlib.ComposerCase):
         b.wait_val("#cmpsr-compon__version-select", "1")
         # group actions end
         b.click("button:contains('Apply Change')")
-        b.wait_present("a:contains('1 Pending Change')")
+        b.wait_visible("a:contains('1 Pending Change')")
 
         # search for openssh-server pacakge
         b.set_input_text("#cmpsr-blueprint-input-filter", "tmux")
@@ -76,21 +76,21 @@ class TestDependence(composerlib.ComposerCase):
         b.click("#blueprint-tabs-tab-dependencies")
         # add tmux to blueprint
         b.click(".cmpsr-header__actions button:contains('Add')")
-        b.wait_present("a:contains('2 Pending Change')")
-        b.wait_present("li[data-component=tmux]")
+        b.wait_visible("a:contains('2 Pending Change')")
+        b.wait_visible("li[data-component=tmux]")
 
         # view tmux detail
         b.click("li[data-component=tmux] #tmux")
         b.wait_visible("#cmpsr-compon__version-select")
         # back to openssh-server
         b.click("a:contains('Back to openssh-server')")
-        b.wait_present("li[data-component=tmux]")
+        b.wait_visible("li[data-component=tmux]")
 
         # remove from tumx detail
         b.click("li[data-component=tmux] #tmux")
         b.wait_visible("#cmpsr-compon__version-select")
         b.click("button:contains('Remove')")
-        b.wait_present("a:contains('1 Pending Change')")
+        b.wait_visible("a:contains('1 Pending Change')")
 
         # collect code coverage result
         self.check_coverage()

--- a/test/verify/check-dependence
+++ b/test/verify/check-dependence
@@ -61,13 +61,8 @@ class TestDependence(composerlib.ComposerCase):
         b.wait_attr("#openssh-server-kebab", "aria-expanded", "true")
         b.click("ul[aria-labelledby=openssh-server-kebab] a:contains('View')")
         # version selection
-        # group actions for select from dropdown menu
-        b.wait_visible("#cmpsr-compon__version-select")
-        version_selector = "#cmpsr-compon__version-select option[value='1']"
-        b.wait_present(version_selector)
-        value_id = b.attr(version_selector, "value")
-        b.set_val("#cmpsr-compon__version-select", value_id)
-        b.wait_val("#cmpsr-compon__version-select", value_id)
+        b.set_val("#cmpsr-compon__version-select", "1")
+        b.wait_val("#cmpsr-compon__version-select", "1")
         # group actions end
         b.click("button:contains('Apply Change')")
         b.wait_present("a:contains('1 Pending Change')")

--- a/test/verify/check-image
+++ b/test/verify/check-image
@@ -127,7 +127,7 @@ class TestImage(composerlib.ComposerCase):
         b.wait_attr("#continue-button", "disabled", "")
         # check and enter authentication fields
         b.click("button:contains('Authentication')")
-        b.wait_present("span:contains('Access key ID')")
+        b.wait_present("label:contains('Access key ID')")
         # check access key id help button
         b.click("button[aria-label='Access key ID help']")
         b.wait_text(".pf-c-popover__body",
@@ -138,7 +138,7 @@ class TestImage(composerlib.ComposerCase):
         # enter access key id value
         b.focus("input[id='access-key-id-input']")
         b.key_press("never")
-        b.wait_present("span:contains('Secret access key')")
+        b.wait_present("label:contains('Secret access key')")
         # check secret access key help button
         b.click("button[aria-label='Secret access key help']")
         b.wait_text(".pf-c-popover__body",
@@ -151,7 +151,7 @@ class TestImage(composerlib.ComposerCase):
         b.key_press("gunna")
         # check and enter destination fields
         b.click("button:contains('Destination')")
-        b.wait_present("span:contains('Image name')")
+        b.wait_present("label:contains('Image name')")
         # check image name help button
         b.click("button[aria-label='Image name help']")
         b.wait_text(".pf-c-popover__body",
@@ -161,7 +161,7 @@ class TestImage(composerlib.ComposerCase):
         # enter access key id value
         b.focus("input[id='image-name-input']")
         b.key_press("give")
-        b.wait_present("span:contains('Amazon S3 bucket')")
+        b.wait_present("label:contains('Amazon S3 bucket')")
         # check amazon s3 bucket help button
         b.click("button[aria-label='S3 Bucket help']")
         b.wait_text(".pf-c-popover__body",
@@ -174,7 +174,7 @@ class TestImage(composerlib.ComposerCase):
         # enter secret access key value
         b.focus("input[id='bucket-input']")
         b.key_press("you")
-        b.wait_present("span:contains('AWS region')")
+        b.wait_present("label:contains('AWS region')")
         # check image name help button
         b.click("button[aria-label='AWS region help']")
         b.wait_text(".pf-c-popover__body",
@@ -250,7 +250,7 @@ class TestImage(composerlib.ComposerCase):
         b.click("#azure-checkbox")
         b.click("button:contains('Next')")
         # check and enter authentication fields
-        b.wait_present("span:contains('Storage account')")
+        b.wait_present("label:contains('Storage account')")
         # check storage account help button
         b.click("button[aria-label='Storage account help']")
         b.wait_text(".pf-c-popover__body",
@@ -261,7 +261,7 @@ class TestImage(composerlib.ComposerCase):
         # enter storage account value
         b.focus("input[id='storage-account-input']")
         b.key_press("never")
-        b.wait_present("span:contains('Storage access key')")
+        b.wait_present("label:contains('Storage access key')")
         # check storage access key help button
         b.click("button[aria-label='Storage access key help']")
         b.wait_text(".pf-c-popover__body",
@@ -275,7 +275,7 @@ class TestImage(composerlib.ComposerCase):
         b.key_press("gunna")
         # check and enter destination fields
         b.click("button:contains('Destination')")
-        b.wait_present("span:contains('Image name')")
+        b.wait_present("label:contains('Image name')")
         # check image name help button
         b.click("button[aria-label='Image name help']")
         b.wait_text(".pf-c-popover__body",
@@ -285,7 +285,7 @@ class TestImage(composerlib.ComposerCase):
         # enter image name id value
         b.focus("input[id='image-name-input']")
         b.key_press("give")
-        b.wait_present("span:contains('Storage container')")
+        b.wait_present("label:contains('Storage container')")
         # check amazon Storage container help button
         b.click("button[aria-label='Storage container help']")
         b.text(".pf-c-popover__body")

--- a/test/verify/check-image
+++ b/test/verify/check-image
@@ -18,7 +18,7 @@ class TestImage(composerlib.ComposerCase):
         b = self.browser
 
         self.login_and_go("/composer", superuser=True)
-        b.wait_present("#main")
+        b.wait_visible("#main")
 
         # create image wizard (no upload support)
         b.click("li[data-blueprint=httpd-server] #create-image-button")
@@ -87,7 +87,7 @@ class TestImage(composerlib.ComposerCase):
         b = self.browser
 
         self.login_and_go("/composer", superuser=True)
-        b.wait_present("#main")
+        b.wait_visible("#main")
 
         # create image wizard
         b.click("li[data-blueprint=httpd-server] #create-image-button")
@@ -127,7 +127,7 @@ class TestImage(composerlib.ComposerCase):
         b.wait_attr("#continue-button", "disabled", "")
         # check and enter authentication fields
         b.click("button:contains('Authentication')")
-        b.wait_present("label:contains('Access key ID')")
+        b.wait_visible("label:contains('Access key ID')")
         # check access key id help button
         b.click("button[aria-label='Access key ID help']")
         b.wait_text(".pf-c-popover__body",
@@ -138,7 +138,7 @@ class TestImage(composerlib.ComposerCase):
         # enter access key id value
         b.focus("input[id='access-key-id-input']")
         b.key_press("never")
-        b.wait_present("label:contains('Secret access key')")
+        b.wait_visible("label:contains('Secret access key')")
         # check secret access key help button
         b.click("button[aria-label='Secret access key help']")
         b.wait_text(".pf-c-popover__body",
@@ -151,7 +151,7 @@ class TestImage(composerlib.ComposerCase):
         b.key_press("gunna")
         # check and enter destination fields
         b.click("button:contains('Destination')")
-        b.wait_present("label:contains('Image name')")
+        b.wait_visible("label:contains('Image name')")
         # check image name help button
         b.click("button[aria-label='Image name help']")
         b.wait_text(".pf-c-popover__body",
@@ -161,7 +161,7 @@ class TestImage(composerlib.ComposerCase):
         # enter access key id value
         b.focus("input[id='image-name-input']")
         b.key_press("give")
-        b.wait_present("label:contains('Amazon S3 bucket')")
+        b.wait_visible("label:contains('Amazon S3 bucket')")
         # check amazon s3 bucket help button
         b.click("button[aria-label='S3 Bucket help']")
         b.wait_text(".pf-c-popover__body",
@@ -174,7 +174,7 @@ class TestImage(composerlib.ComposerCase):
         # enter secret access key value
         b.focus("input[id='bucket-input']")
         b.key_press("you")
-        b.wait_present("label:contains('AWS region')")
+        b.wait_visible("label:contains('AWS region')")
         # check image name help button
         b.click("button[aria-label='AWS region help']")
         b.wait_text(".pf-c-popover__body",
@@ -212,7 +212,7 @@ class TestImage(composerlib.ComposerCase):
         b.wait_in_text("#aws-content", "AWS region")
         b.wait_in_text("#aws-content", "up")
         # continue button changes to Finish when upload has valid fields
-        b.wait_present("button:contains('Finish'):enabled")
+        b.wait_visible("button:contains('Finish'):enabled")
         # Close wizard
         b.click("button:contains('Cancel')")
         b.wait_not_present("#create-image-upload-wizard")
@@ -224,7 +224,7 @@ class TestImage(composerlib.ComposerCase):
         b = self.browser
 
         self.login_and_go("/composer", superuser=True)
-        b.wait_present("#main")
+        b.wait_visible("#main")
 
         # create image wizard
         b.click("li[data-blueprint=httpd-server] #create-image-button")
@@ -250,7 +250,7 @@ class TestImage(composerlib.ComposerCase):
         b.click("#azure-checkbox")
         b.click("button:contains('Next')")
         # check and enter authentication fields
-        b.wait_present("label:contains('Storage account')")
+        b.wait_visible("label:contains('Storage account')")
         # check storage account help button
         b.click("button[aria-label='Storage account help']")
         b.wait_text(".pf-c-popover__body",
@@ -261,7 +261,7 @@ class TestImage(composerlib.ComposerCase):
         # enter storage account value
         b.focus("input[id='storage-account-input']")
         b.key_press("never")
-        b.wait_present("label:contains('Storage access key')")
+        b.wait_visible("label:contains('Storage access key')")
         # check storage access key help button
         b.click("button[aria-label='Storage access key help']")
         b.wait_text(".pf-c-popover__body",
@@ -275,7 +275,7 @@ class TestImage(composerlib.ComposerCase):
         b.key_press("gunna")
         # check and enter destination fields
         b.click("button:contains('Destination')")
-        b.wait_present("label:contains('Image name')")
+        b.wait_visible("label:contains('Image name')")
         # check image name help button
         b.click("button[aria-label='Image name help']")
         b.wait_text(".pf-c-popover__body",
@@ -285,7 +285,7 @@ class TestImage(composerlib.ComposerCase):
         # enter image name id value
         b.focus("input[id='image-name-input']")
         b.key_press("give")
-        b.wait_present("label:contains('Storage container')")
+        b.wait_visible("label:contains('Storage container')")
         # check amazon Storage container help button
         b.click("button[aria-label='Storage container help']")
         b.text(".pf-c-popover__body")
@@ -319,7 +319,7 @@ class TestImage(composerlib.ComposerCase):
         b.wait_in_text("#azure-content", "Storage container")
         b.wait_in_text("#azure-content", "you-up")
         # continue button changes to Finish when upload has valid fields
-        b.wait_present("button:contains('Finish'):enabled")
+        b.wait_visible("button:contains('Finish'):enabled")
         # Close wizard
         b.click("button:contains('Cancel')")
         b.wait_not_present("#create-image-upload-wizard")
@@ -332,7 +332,7 @@ class TestImage(composerlib.ComposerCase):
         m = self.machine
 
         self.login_and_go("/composer", superuser=True)
-        b.wait_present("#main")
+        b.wait_visible("#main")
 
         # create image wizard
         b.click("li[data-blueprint=httpd-server] #create-image-button")
@@ -349,7 +349,7 @@ class TestImage(composerlib.ComposerCase):
         b.wait_not_present("#create-image-upload-wizard")
 
         # toast notification
-        b.wait_present("#cmpsr-toast-imageWaiting .pficon-info")
+        b.wait_visible("#cmpsr-toast-imageWaiting .pficon-info")
         b.click("#cmpsr-toast-imageWaiting .pficon-close")
         b.wait_not_present("#cmpsr-toast-imageWaiting .pficon-info")
 
@@ -358,7 +358,7 @@ class TestImage(composerlib.ComposerCase):
         # correct image name and type
         with b.wait_timeout(300):
             b.click("#blueprint-tabs-tab-images")
-            b.wait_present("ul[data-list=images]")
+            b.wait_visible("ul[data-list=images]")
         # get uuid as part of css selector
         uuid = m.execute("""
             composer-cli compose list | grep httpd-server | awk '{print $1}' | head -1
@@ -426,7 +426,7 @@ class TestImage(composerlib.ComposerCase):
             image_type_ostree = "rhel-edge-commit"
 
         self.login_and_go("/composer", superuser=True)
-        b.wait_present("#main")
+        b.wait_visible("#main")
 
         # create image wizard
         b.click("li[data-blueprint=httpd-server] #create-image-button")
@@ -437,7 +437,7 @@ class TestImage(composerlib.ComposerCase):
         b.click("#continue-button")
         b.wait_not_present("#create-image-upload-wizard")
         # toast notification
-        b.wait_present("#cmpsr-toast-imageWaiting .pficon-info")
+        b.wait_visible("#cmpsr-toast-imageWaiting .pficon-info")
         b.click("#cmpsr-toast-imageWaiting .pficon-close")
         b.wait_not_present("#cmpsr-toast-imageWaiting .pficon-info")
 
@@ -446,7 +446,7 @@ class TestImage(composerlib.ComposerCase):
         # correct image name and type
         with b.wait_timeout(300):
             b.click("#blueprint-tabs-tab-images")
-            b.wait_present("ul[data-list=images]")
+            b.wait_visible("ul[data-list=images]")
         # get uuid as part of css selector
         uuid = m.execute("""
             composer-cli compose list | grep httpd-server | awk '{print $1}' | head -1
@@ -497,7 +497,7 @@ class TestImage(composerlib.ComposerCase):
         m = self.machine
 
         self.login_and_go("/composer", superuser=True)
-        b.wait_present("#main")
+        b.wait_visible("#main")
 
         # create image wizard
         b.click("li[data-blueprint=httpd-server] #create-image-button")
@@ -510,7 +510,7 @@ class TestImage(composerlib.ComposerCase):
         b.wait_not_present("#create-image-upload-wizard")
 
         # toast notification
-        b.wait_present("#cmpsr-toast-imageWaiting .pficon-info")
+        b.wait_visible("#cmpsr-toast-imageWaiting .pficon-info")
         b.click("#cmpsr-toast-imageWaiting .pficon-close")
         b.wait_not_present("#cmpsr-toast-imageWaiting .pficon-info")
 
@@ -519,7 +519,7 @@ class TestImage(composerlib.ComposerCase):
         # correct image name and type
         with b.wait_timeout(300):
             b.click("#blueprint-tabs-tab-images")
-            b.wait_present("ul[data-list=images]")
+            b.wait_visible("ul[data-list=images]")
         # get uuid as part of css selector
         uuid = m.execute("""
             composer-cli compose list | grep httpd-server | awk '{print $1}' | head -1

--- a/test/verify/check-image
+++ b/test/verify/check-image
@@ -30,13 +30,9 @@ class TestImage(composerlib.ComposerCase):
         b.click(".pf-c-popover__content button")
         b.wait_not_present(".pf-c-popover__body")
         # check non upload image action (Create only)
-        # group actions for select from dropdown menu
-        b.wait_visible("#image-type")
-        test_selector = "#image-type option[value='qcow2']"
-        b.wait_present(test_selector)
-        value_id = b.attr(test_selector, "value")
-        b.set_val("#image-type", value_id)
-        b.wait_val("#image-type", value_id)
+        b.wait_js_cond('ph_select("#image-type option").length > 1')
+        b.set_val("#image-type", "qcow2")
+        b.wait_val("#image-type", "qcow2")
         # check ? (image size help) button
         b.click("button[aria-label='Image size help']")
         b.wait_text(".pf-c-popover__body",
@@ -95,13 +91,9 @@ class TestImage(composerlib.ComposerCase):
 
         # create image wizard
         b.click("li[data-blueprint=httpd-server] #create-image-button")
-        # group actions for select from dropdown menu
-        b.wait_visible("#image-type")
-        test_selector = "#image-type option[value='ami']"
-        b.wait_present(test_selector)
-        value_id = b.attr(test_selector, "value")
-        b.set_val("#image-type", value_id)
-        b.wait_val("#image-type", value_id)
+        b.wait_js_cond('ph_select("#image-type option").length > 1')
+        b.set_val("#image-type", "ami")
+        b.wait_val("#image-type", "ami")
         # groups action done
         # still keep Create if upload image not selected
         b.wait_text("#continue-button", "Create")
@@ -236,13 +228,9 @@ class TestImage(composerlib.ComposerCase):
 
         # create image wizard
         b.click("li[data-blueprint=httpd-server] #create-image-button")
-        # group actions for select from dropdown menu
-        b.wait_visible("#image-type")
-        test_selector = "#image-type option[value='vhd']"
-        b.wait_present(test_selector)
-        value_id = b.attr(test_selector, "value")
-        b.set_val("#image-type", value_id)
-        b.wait_val("#image-type", value_id)
+        b.wait_js_cond('ph_select("#image-type option").length > 1')
+        b.set_val("#image-type", "vhd")
+        b.wait_val("#image-type", "vhd")
         # groups action done
         # still keep Create if upload image not selected
         b.wait_text("#continue-button", "Create")
@@ -349,13 +337,9 @@ class TestImage(composerlib.ComposerCase):
         # create image wizard
         b.click("li[data-blueprint=httpd-server] #create-image-button")
         b.wait_text("#create-image-upload-wizard #blueprint-name", "httpd-server")
-        # group actions for select from dropdown menu
-        b.wait_visible("#image-type")
-        test_selector = "#image-type option[value='openstack']"
-        b.wait_present(test_selector)
-        value_id = b.attr(test_selector, "value")
-        b.set_val("#image-type", value_id)
-        b.wait_val("#image-type", value_id)
+        b.wait_js_cond('ph_select("#image-type option").length > 1')
+        b.set_val("#image-type", "openstack")
+        b.wait_val("#image-type", "openstack")
         # group actions end
         b.focus("#image-size-input")
         # delete 2 and input 4
@@ -447,14 +431,9 @@ class TestImage(composerlib.ComposerCase):
         # create image wizard
         b.click("li[data-blueprint=httpd-server] #create-image-button")
         b.wait_text("#create-image-upload-wizard #blueprint-name", "httpd-server")
-        # group actions for select from dropdown menu
-        b.wait_visible("#image-type")
-        test_selector = "#image-type option[value='{image_type}']".format(
-            image_type=image_type_ostree)
-        b.wait_present(test_selector)
-        value_id = b.attr(test_selector, "value")
-        b.set_val("#image-type", value_id)
-        b.wait_val("#image-type", value_id)
+        b.wait_js_cond('ph_select("#image-type option").length > 1')
+        b.set_val("#image-type", image_type_ostree)
+        b.wait_val("#image-type", image_type_ostree)
         b.click("#continue-button")
         b.wait_not_present("#create-image-upload-wizard")
         # toast notification
@@ -523,13 +502,9 @@ class TestImage(composerlib.ComposerCase):
         # create image wizard
         b.click("li[data-blueprint=httpd-server] #create-image-button")
         b.wait_text("#create-image-upload-wizard #blueprint-name", "httpd-server")
-        # group actions for select from dropdown menu
-        b.wait_visible("#image-type")
-        test_selector = "#image-type option[value='openstack']"
-        b.wait_present(test_selector)
-        value_id = b.attr(test_selector, "value")
-        b.set_val("#image-type", value_id)
-        b.wait_val("#image-type", value_id)
+        b.wait_js_cond('ph_select("#image-type option").length > 1')
+        b.set_val("#image-type", "openstack")
+        b.wait_val("#image-type", "openstack")
         # group actions end
         b.click("#continue-button")
         b.wait_not_present("#create-image-upload-wizard")

--- a/test/verify/check-package
+++ b/test/verify/check-package
@@ -34,7 +34,7 @@ class TestPackage(composerlib.ComposerCase):
         b.key_press("\r")
         with b.wait_timeout(120):
             b.wait_text("#cockpit-bridge-input", "cockpit-bridge")
-        b.wait_present(".toolbar-pf-results .label-info span")
+        b.wait_present(".toolbar-pf-results .label-info > span")
         # click Clear All Filters link
         b.click("span:contains('Clear All Filters')")
         b.wait_present("ul[aria-label='Available Components'] li:nth-child(1)")
@@ -155,9 +155,9 @@ class TestPackage(composerlib.ComposerCase):
         # pending commit
         b.click("a:contains('1 Pending Change')")
         # show Added cockpit-bridge
-        b.wait_present("#cmpsr-modal-pending-changes ul li:nth-child(1) div:contains('Added')")
+        b.wait_present("#cmpsr-modal-pending-changes ul li:nth-child(1) .row:contains('Added')")
         b.wait_present("#cmpsr-modal-pending-changes ul li:nth-child(1) "
-                       "div:contains('cockpit-bridge-*')")
+                       ".row:contains('cockpit-bridge-*')")
         b.click("#cmpsr-modal-pending-changes button:contains('Close')")
         b.wait_not_present("#cmpsr-modal-pending-changes")
 
@@ -177,15 +177,15 @@ class TestPackage(composerlib.ComposerCase):
         # commit
         b.click("button:contains('Commit')")
         b.wait_present("#cmpsr-modal-pending-changes .form-horizontal p + div ul "
-                       "li:nth-child(1) div:contains('Removed')")
+                       "li:nth-child(1) .row:contains('Removed')")
         b.wait_present("#cmpsr-modal-pending-changes .form-horizontal p + div ul "
-                       "li:nth-child(1) div:contains('cockpit-bridge-*')")
+                       "li:nth-child(1) .row:contains('cockpit-bridge-*')")
         b.wait_in_text("#cmpsr-modal-pending-changes .form-horizontal p + div + div > strong",
                        "Changes made in a previous session")
         b.wait_present("#cmpsr-modal-pending-changes .form-horizontal p + div + div ul "
-                       "li:nth-child(1) div:contains('Added')")
+                       "li:nth-child(1) .row:contains('Added')")
         b.wait_present("#cmpsr-modal-pending-changes .form-horizontal p + div + div ul "
-                       "li:nth-child(1) div:contains('cockpit-bridge-*')")
+                       "li:nth-child(1) .row:contains('cockpit-bridge-*')")
         b.click("#cmpsr-modal-pending-changes .modal-footer button:contains('Commit')")
         # toast notification appear and disappear automatically
         b.wait_present("#cmpsr-toast-committed")

--- a/test/verify/check-package
+++ b/test/verify/check-package
@@ -17,27 +17,27 @@ class TestPackage(composerlib.ComposerCase):
         b = self.browser
 
         self.login_and_go("/composer", superuser=True)
-        b.wait_present("#main")
+        b.wait_visible("#main")
 
         # go to edit package page
         b.click("li[data-blueprint=httpd-server] a:contains('Edit Packages')")
         with b.wait_timeout(120):
-            b.wait_present("ul[aria-label='Available Components'] li:nth-child(1)")
+            b.wait_visible("ul[aria-label='Available Components'] li:nth-child(1)")
 
         # do navigate with > and < button
         b.click("button[aria-label='Go to next page']")
-        b.wait_present("ul[aria-label='Available Components'] li:nth-child(1)")
+        b.wait_visible("ul[aria-label='Available Components'] li:nth-child(1)")
         b.click("button[aria-label='Go to previous page']")
-        b.wait_present("ul[aria-label='Available Components'] li:nth-child(1)")
+        b.wait_visible("ul[aria-label='Available Components'] li:nth-child(1)")
         # filter on avaliable components
         b.set_input_text("#cmpsr-blueprint-input-filter", "cockpit-bridge")
         b.key_press("\r")
         with b.wait_timeout(120):
             b.wait_text("#cockpit-bridge-input", "cockpit-bridge")
-        b.wait_present(".toolbar-pf-results .label-info > span")
+        b.wait_visible(".toolbar-pf-results .label-info > span")
         # click Clear All Filters link
         b.click("span:contains('Clear All Filters')")
-        b.wait_present("ul[aria-label='Available Components'] li:nth-child(1)")
+        b.wait_visible("ul[aria-label='Available Components'] li:nth-child(1)")
         b.wait_not_present(".toolbar-pf-results .label-info span")
         b.wait_not_present("#cockpit-bridge-input")
 
@@ -80,12 +80,12 @@ class TestPackage(composerlib.ComposerCase):
         b = self.browser
 
         self.login_and_go("/composer", superuser=True)
-        b.wait_present("#main")
+        b.wait_visible("#main")
 
         # go to edit package page
         b.click("li[data-blueprint=httpd-server] a:contains('Edit Packages')")
         with b.wait_timeout(120):
-            b.wait_present("ul[aria-label='Available Components'] li:nth-child(1)")
+            b.wait_visible("ul[aria-label='Available Components'] li:nth-child(1)")
 
         blueprint_list = [
             "httpd",
@@ -93,16 +93,16 @@ class TestPackage(composerlib.ComposerCase):
             "vim-enhanced"
         ]
         # sort from Z-A
-        b.wait_present("ul[aria-label='Selected Components']")
+        b.wait_visible("ul[aria-label='Selected Components']")
         b.click(".fa-sort-alpha-asc")
-        b.wait_present(".fa-sort-alpha-desc")
+        b.wait_visible(".fa-sort-alpha-desc")
         for i, v in enumerate(sorted(blueprint_list, reverse=True)):
             b.wait_text("ul[aria-label='Selected Components'] li:nth-child({}) "
                         "a strong".format(i + 1), v)
 
         # sort from A-Z
         b.click(".fa-sort-alpha-desc")
-        b.wait_present(".fa-sort-alpha-asc")
+        b.wait_visible(".fa-sort-alpha-asc")
         for i, v in enumerate(sorted(blueprint_list)):
             b.wait_text("ul[aria-label='Selected Components'] li:nth-child({}) "
                         "a strong".format(i + 1), v)
@@ -114,12 +114,12 @@ class TestPackage(composerlib.ComposerCase):
         b = self.browser
 
         self.login_and_go("/composer", superuser=True)
-        b.wait_present("#main")
+        b.wait_visible("#main")
 
         # go to edit package page
         b.click("li[data-blueprint=openssh-server] a:contains('Edit Packages')")
         with b.wait_timeout(120):
-            b.wait_present("ul[aria-label='Available Components'] li:nth-child(1)")
+            b.wait_visible("ul[aria-label='Available Components'] li:nth-child(1)")
 
         # search for openssh-server pacakge
         b.set_input_text("#cmpsr-blueprint-input-filter", "cockpit-bridge")
@@ -129,11 +129,11 @@ class TestPackage(composerlib.ComposerCase):
         # add it to blueprint
         b.click("li[data-input=cockpit-bridge] .fa-plus")
         # wait for package added
-        b.wait_present("li[data-component=cockpit-bridge]")
+        b.wait_visible("li[data-component=cockpit-bridge]")
         # + becomes -
-        b.wait_present("li[data-input=cockpit-bridge] .fa-minus")
+        b.wait_visible("li[data-input=cockpit-bridge] .fa-minus")
         # bordered icon
-        b.wait_present("li[data-input=cockpit-bridge] .list-pf-icon-bordered")
+        b.wait_visible("li[data-input=cockpit-bridge] .list-pf-icon-bordered")
         # redo button should be disabled
         b.wait_attr_contains("button[data-button=redo]", "class", "disabled")
 
@@ -142,21 +142,21 @@ class TestPackage(composerlib.ComposerCase):
         b.wait_not_present("li[data-component=cockpit-bridge]")
         b.wait_attr_contains("button[data-button=undo]", "class", "disabled")
         # - becomes +
-        b.wait_present("li[data-input=cockpit-bridge] .fa-plus")
+        b.wait_visible("li[data-input=cockpit-bridge] .fa-plus")
         # no bordered icon
         b.wait_not_present("li[data-input=cockpit-bridge] .list-pf-icon-bordered")
 
         # redo
         b.click("button[data-button=redo]")
-        b.wait_present("li[data-component=cockpit-bridge]")
+        b.wait_visible("li[data-component=cockpit-bridge]")
         # undo button should be disabled
         b.wait_attr_contains("button[data-button=redo]", "class", "disabled")
 
         # pending commit
         b.click("a:contains('1 Pending Change')")
         # show Added cockpit-bridge
-        b.wait_present("#cmpsr-modal-pending-changes ul li:nth-child(1) .row:contains('Added')")
-        b.wait_present("#cmpsr-modal-pending-changes ul li:nth-child(1) "
+        b.wait_visible("#cmpsr-modal-pending-changes ul li:nth-child(1) .row:contains('Added')")
+        b.wait_visible("#cmpsr-modal-pending-changes ul li:nth-child(1) "
                        ".row:contains('cockpit-bridge-*')")
         b.click("#cmpsr-modal-pending-changes button:contains('Close')")
         b.wait_not_present("#cmpsr-modal-pending-changes")
@@ -164,31 +164,31 @@ class TestPackage(composerlib.ComposerCase):
         # logout and login, still in edit blueprint page
         with b.wait_timeout(300):
             b.relogin("/composer", superuser=True)
-        b.wait_present("ul[aria-label='Available Components'] li:nth-child(1)")
+        b.wait_visible("ul[aria-label='Available Components'] li:nth-child(1)")
 
         # "1 Pending Change" still there
-        b.wait_present("a:contains('1 Pending Change')")
+        b.wait_visible("a:contains('1 Pending Change')")
         b.click("#cockpit-bridge-kebab")
         b.wait_attr("#cockpit-bridge-kebab", "aria-expanded", "true")
         b.click("ul[aria-labelledby=cockpit-bridge-kebab] a:contains('Remove')")
         b.wait_not_present("li[data-component=cockpit-bridge]")
         # "2 Pending Change" now
-        b.wait_present("a:contains('2 Pending Change')")
+        b.wait_visible("a:contains('2 Pending Change')")
         # commit
         b.click("button:contains('Commit')")
-        b.wait_present("#cmpsr-modal-pending-changes .form-horizontal p + div ul "
+        b.wait_visible("#cmpsr-modal-pending-changes .form-horizontal p + div ul "
                        "li:nth-child(1) .row:contains('Removed')")
-        b.wait_present("#cmpsr-modal-pending-changes .form-horizontal p + div ul "
+        b.wait_visible("#cmpsr-modal-pending-changes .form-horizontal p + div ul "
                        "li:nth-child(1) .row:contains('cockpit-bridge-*')")
         b.wait_in_text("#cmpsr-modal-pending-changes .form-horizontal p + div + div > strong",
                        "Changes made in a previous session")
-        b.wait_present("#cmpsr-modal-pending-changes .form-horizontal p + div + div ul "
+        b.wait_visible("#cmpsr-modal-pending-changes .form-horizontal p + div + div ul "
                        "li:nth-child(1) .row:contains('Added')")
-        b.wait_present("#cmpsr-modal-pending-changes .form-horizontal p + div + div ul "
+        b.wait_visible("#cmpsr-modal-pending-changes .form-horizontal p + div + div ul "
                        "li:nth-child(1) .row:contains('cockpit-bridge-*')")
         b.click("#cmpsr-modal-pending-changes .modal-footer button:contains('Commit')")
         # toast notification appear and disappear automatically
-        b.wait_present("#cmpsr-toast-committed")
+        b.wait_visible("#cmpsr-toast-committed")
         with b.wait_timeout(120):
             b.wait_not_present("#cmpsr-toast-committed")
         # disabled commit button
@@ -201,12 +201,12 @@ class TestPackage(composerlib.ComposerCase):
         b = self.browser
 
         self.login_and_go("/composer", superuser=True)
-        b.wait_present("#main")
+        b.wait_visible("#main")
 
         # go to edit package page
         b.click("li[data-blueprint=openssh-server] a:contains('Edit Packages')")
         with b.wait_timeout(240):
-            b.wait_present("ul[aria-label='Available Components'] li:nth-child(1)")
+            b.wait_visible("ul[aria-label='Available Components'] li:nth-child(1)")
 
         # search for openssh-server pacakge
         b.set_input_text("#cmpsr-blueprint-input-filter", "cockpit-composer")
@@ -216,7 +216,7 @@ class TestPackage(composerlib.ComposerCase):
         # add it to blueprint
         b.click("li[data-input=cockpit-composer] .fa-plus")
         # wait for package added
-        b.wait_present("li[data-component=cockpit-composer]")
+        b.wait_visible("li[data-component=cockpit-composer]")
         # click discard changes button
         b.click("button:contains('Discard Changes')")
         b.wait_not_present("li[data-component=cockpit-composer]")

--- a/test/verify/check-service
+++ b/test/verify/check-service
@@ -34,7 +34,7 @@ class TestService(composerlib.ComposerCase):
         b = self.browser
 
         self.login_and_go("/composer", superuser=True)
-        b.wait_present("#main")
+        b.wait_visible("#main")
 
         # start and enable osbuild-composer from UI
         b.click("button:contains('Start')")
@@ -48,7 +48,7 @@ class TestService(composerlib.ComposerCase):
         desc_template = string.ascii_letters + string.digits + " "
         bp_desc = "".join(random.sample(desc_template, 40))
         b.click(".pf-c-empty-state button:contains('Create Blueprint')")
-        b.wait_present("div[role=dialog] #cmpsr-modal-crt-blueprint")
+        b.wait_visible("div[role=dialog] #cmpsr-modal-crt-blueprint")
         # blueprint name
         b.set_input_text("#textInput-modal-markup", bp_name)
         # blueprint description
@@ -59,7 +59,7 @@ class TestService(composerlib.ComposerCase):
 
         # wait for all available compontents visible
         with b.wait_timeout(300):
-            b.wait_present("ul[data-list=inputs]")
+            b.wait_visible("ul[data-list=inputs]")
         # search for openssh-server pacakge
         b.set_input_text("#cmpsr-blueprint-input-filter", "openssh-server")
         b.key_press("\r")
@@ -68,8 +68,8 @@ class TestService(composerlib.ComposerCase):
         # add it to blueprint
         b.click("li[data-input=openssh-server] .fa-plus")
         # wait for package added
-        b.wait_present("#blueprint-tabs")
-        b.wait_present("li[data-component=openssh-server]")
+        b.wait_visible("#blueprint-tabs")
+        b.wait_visible("li[data-component=openssh-server]")
         # click commit button
         b.click(".cmpsr-header__actions .btn-primary")
         # click commit button
@@ -77,7 +77,7 @@ class TestService(composerlib.ComposerCase):
         b.wait_not_present("#cmpsr-modal-pending-changes")
 
         # wait for toast notification dialog
-        b.wait_present("#cmpsr-toast-committed .pficon-ok")
+        b.wait_visible("#cmpsr-toast-committed .pficon-ok")
         # click close button
         b.click("#cmpsr-toast-committed .pficon-close")
         b.wait_not_present("#cmpsr-toast-committed .pficon-ok")
@@ -121,7 +121,7 @@ class TestService(composerlib.ComposerCase):
             m.execute("systemctl disable --now osbuild-local-worker.socket")
 
         self.login_and_go("/composer", superuser=True)
-        b.wait_present("#main")
+        b.wait_visible("#main")
 
         # do not enable osbuild-composer
         b.click(".checkbox input")
@@ -150,10 +150,10 @@ class TestService(composerlib.ComposerCase):
             m.execute("systemctl disable --now osbuild-local-worker.socket")
 
         self.login_and_go("/composer", superuser=False)
-        b.wait_present("#main")
+        b.wait_visible("#main")
 
         # Start button can be disabled button or clickable button
-        b.wait_present("button:contains('Start')")
+        b.wait_visible("button:contains('Start')")
 
         # disable this test due to https://github.com/osbuild/cockpit-composer/issues/941
         # if "disabled" not in b.attr("button:contains('Start')", "class"):

--- a/test/verify/check-source
+++ b/test/verify/check-source
@@ -48,14 +48,8 @@ class TestSource(composerlib.ComposerCase):
         b.click("input[value='Add Source']")
         b.set_input_text("#textInput1-modal-source", repo_name)
         b.set_input_text("#textInput2-modal-source", repo_url)
-        # group actions for select from dropdown menu
-        dropdown_menu_sel = "#textInput3-modal-source"
-        b.wait_visible(dropdown_menu_sel)
-        test_selector = "{} option[value='yum-baseurl']".format(dropdown_menu_sel)
-        b.wait_present(test_selector)
-        value_id = b.attr(test_selector, "value")
-        b.set_val(dropdown_menu_sel, value_id)
-        b.wait_val(dropdown_menu_sel, value_id)
+        b.set_val("#textInput3-modal-source", "yum-baseurl")
+        b.wait_val("#textInput3-modal-source", "yum-baseurl")
         # groups action done
         b.click("button:contains('Add Source')")
 

--- a/test/verify/check-source
+++ b/test/verify/check-source
@@ -21,7 +21,7 @@ class TestSource(composerlib.ComposerCase):
         repo_name = "sway-copr"
 
         self.login_and_go("/composer", superuser=True)
-        b.wait_present("#main")
+        b.wait_visible("#main")
 
         # open manage sources dialog
         drop_down_sel = ".toolbar-pf-action-right #dropdownKebab"
@@ -29,12 +29,12 @@ class TestSource(composerlib.ComposerCase):
         b.wait_attr(drop_down_sel, "aria-expanded", "true")
         b.click("a:contains('Manage Sources')")
         b.wait_attr(drop_down_sel, "aria-expanded", "false")
-        b.wait_present("#cmpsr-modal-manage-sources")
+        b.wait_visible("#cmpsr-modal-manage-sources")
 
         # check default loaded sources
         sources = m.execute("composer-cli sources list").split()
         for source in sources:
-            b.wait_present("div[data-source={}]".format(source))
+            b.wait_visible("div[data-source={}]".format(source))
 
         # add new source
         b.click("input[value='Add Source']")
@@ -62,7 +62,7 @@ class TestSource(composerlib.ComposerCase):
             b.wait_attr(drop_down_sel, "aria-expanded", "true")
             b.click("a:contains('Manage Sources')")
             b.wait_attr(drop_down_sel, "aria-expanded", "false")
-            b.wait_present("#cmpsr-modal-manage-sources")
+            b.wait_visible("#cmpsr-modal-manage-sources")
 
         # endit new source to enable check SSL certificate and GPG key
         b.click("button[aria-label='Edit Source {}']".format(repo_name))
@@ -77,7 +77,7 @@ class TestSource(composerlib.ComposerCase):
         b.click("li[data-blueprint=openssh-server] a:contains('Edit Packages')")
         # wait for all available compontents visible
         with b.wait_timeout(300):
-            b.wait_present("ul[data-list=inputs]")
+            b.wait_visible("ul[data-list=inputs]")
         # search for kanshi which exists in added repo only
         b.set_input_text("#cmpsr-blueprint-input-filter", "kanshi")
         b.key_press("\r")
@@ -91,7 +91,7 @@ class TestSource(composerlib.ComposerCase):
         b.wait_attr(drop_down_sel, "aria-expanded", "true")
         b.click("a:contains('Manage Sources')")
         b.wait_attr(drop_down_sel, "aria-expanded", "false")
-        b.wait_present("#cmpsr-modal-manage-sources")
+        b.wait_visible("#cmpsr-modal-manage-sources")
 
         # duplicated source can't be added
         b.click("input[value='Add Source']")


### PR DESCRIPTION
`wait_present` should be used just rarely as the meaning of this
function is "Wait until present in dom", while meaning of `wait_visible`
is "Wait until in dom and visible to user". Tests should really just
check what user sees. Using `wait_present` incorrectly can lead to
broken code (just now I was fixing accordion which would never open up,
but tests were happy as they were just checking with `wait_present`)

I haven't tried this, just `sed` it. Lets see what CI think :)