### PR TITLE
Use sentence case rather than title case

### DIFF
--- a/components/EmptyState/EmptyStateInactive.js
+++ b/components/EmptyState/EmptyStateInactive.js
@@ -9,7 +9,7 @@ import EmptyState from "./EmptyState";
 
 const messages = defineMessages({
   errorInactiveTitle: {
-    defaultMessage: "Image Building Service is Not Active",
+    defaultMessage: "Image building service is not active",
   },
   errorInactivePrimary: {
     defaultMessage: "Start",

--- a/components/ListView/BlueprintContents.js
+++ b/components/ListView/BlueprintContents.js
@@ -17,16 +17,16 @@ const messages = defineMessages({
     defaultMessage: "An error occurred while trying to get blueprint contents.",
   },
   emptyStateErrorTitle: {
-    defaultMessage: "An Error Occurred",
+    defaultMessage: "An error occurred",
   },
   emptyStateNoResultsMessage: {
     defaultMessage: "Modify your filter criteria to get results.",
   },
   emptyStateNoResultsTitle: {
-    defaultMessage: "No Results Match the Filter Criteria",
+    defaultMessage: "No results match the filter criteria",
   },
   selectedTabTitle: {
-    defaultMessage: "Selected Components",
+    defaultMessage: "Selected components",
   },
 });
 
@@ -50,7 +50,7 @@ const BlueprintContents = (props) => {
   const alertAction =
     pastLength > 0 ? (
       <button className="pf-c-button pf-m-link" type="button" onClick={() => undo()}>
-        <FormattedMessage defaultMessage="Undo Last Change" />
+        <FormattedMessage defaultMessage="Undo last change" />
       </button>
     ) : null;
 
@@ -69,7 +69,7 @@ const BlueprintContents = (props) => {
                   message={formatMessage(messages.emptyStateNoResultsMessage)}
                 >
                   <button className="btn btn-link btn-lg" type="button" onClick={() => filterClearValues([])}>
-                    <FormattedMessage defaultMessage="Clear All Filters" />
+                    <FormattedMessage defaultMessage="Clear all filters" />
                   </button>
                 </EmptyState>
               )) || (
@@ -122,7 +122,7 @@ const BlueprintContents = (props) => {
                   message={formatMessage(messages.emptyStateNoResultsMessage)}
                 >
                   <button className="btn btn-link btn-lg" type="button" onClick={() => filterClearValues([])}>
-                    <FormattedMessage defaultMessage="Clear All Filters" />
+                    <FormattedMessage defaultMessage="Clear all filters" />
                   </button>
                 </EmptyState>
               )) || (

--- a/components/ListView/BlueprintsDataList.js
+++ b/components/ListView/BlueprintsDataList.js
@@ -44,7 +44,7 @@ class BlueprintsDataList extends React.PureComponent {
               />
               <div className="pf-c-data-list__item-action cc-m-nowrap">
                 <Link to={`/edit/${blueprint.name}`} className="btn btn-default">
-                  <FormattedMessage defaultMessage="Edit Packages" />
+                  <FormattedMessage defaultMessage="Edit packages" />
                 </Link>
                 <CreateImageUpload blueprint={blueprint} layout={layout} />
                 <div className="dropdown pull-right dropdown-kebab-pf">

--- a/components/ListView/ComponentDetailsView.js
+++ b/components/ListView/ComponentDetailsView.js
@@ -19,13 +19,13 @@ const messages = defineMessages({
     defaultMessage: "Dependencies",
   },
   hideDetails: {
-    defaultMessage: "Hide Details",
+    defaultMessage: "Hide details",
   },
   removeFromBlueprint: {
-    defaultMessage: "Remove from Blueprint",
+    defaultMessage: "Remove from blueprint",
   },
   noDepsTitle: {
-    defaultMessage: "No Dependencies",
+    defaultMessage: "No dependencies",
   },
   noDepsMessage: {
     defaultMessage: "This component has no dependencies.",
@@ -209,7 +209,7 @@ class ComponentDetailsView extends React.Component {
                       type="button"
                       onClick={(e) => handleUpdateComponent(e, component, component.builds[selectedBuildIndex].version)}
                     >
-                      <FormattedMessage defaultMessage="Apply Change" />
+                      <FormattedMessage defaultMessage="Apply change" />
                     </button>
                   </li>
                 )}
@@ -250,7 +250,7 @@ class ComponentDetailsView extends React.Component {
         {handleUpdateComponent !== undefined && component.builds !== undefined && component.builds.length > 1 && (
           <div className="cmpsr-component-details__form">
             <h4>
-              <FormattedMessage defaultMessage="Component Options" />
+              <FormattedMessage defaultMessage="Component options" />
             </h4>
             <form className="form-horizontal">
               <div className="form-group">

--- a/components/ListView/ComponentInputs.js
+++ b/components/ListView/ComponentInputs.js
@@ -14,16 +14,16 @@ import ComponentTypeIcons from "./ComponentTypeIcons";
 
 const messages = defineMessages({
   hideDetails: {
-    defaultMessage: "Hide Details",
+    defaultMessage: "Hide details",
   },
   showDetails: {
-    defaultMessage: "Show Details and More Options",
+    defaultMessage: "Show details and more options",
   },
   addComponent: {
     defaultMessage: "Add latest version",
   },
   removeComponent: {
-    defaultMessage: "Remove Component from Blueprint",
+    defaultMessage: "Remove component from blueprint",
   },
 });
 

--- a/components/ListView/ComponentSummaryList.js
+++ b/components/ListView/ComponentSummaryList.js
@@ -47,9 +47,9 @@ class ComponentSummaryList extends React.Component {
           <SplitItem>
             <Button variant="link" isInline onClick={(e) => this.handleShowAll(e)}>
               {this.state.showAll ? (
-                <FormattedMessage defaultMessage="Show Less" />
+                <FormattedMessage defaultMessage="Show less" />
               ) : (
-                <FormattedMessage defaultMessage="Show All" />
+                <FormattedMessage defaultMessage="Show all" />
               )}
             </Button>
           </SplitItem>

--- a/components/ListView/SourcesListItem.js
+++ b/components/ListView/SourcesListItem.js
@@ -5,13 +5,13 @@ import { Spinner } from "patternfly-react";
 
 const messages = defineMessages({
   edit: {
-    defaultMessage: "Edit Source",
+    defaultMessage: "Edit source",
   },
   kebab: {
-    defaultMessage: "Source Actions",
+    defaultMessage: "Source actions",
   },
   remove: {
-    defaultMessage: "Remove Source",
+    defaultMessage: "Remove source",
   },
   baseurl: {
     defaultMessage: "yum repository",

--- a/components/Modal/CreateBlueprint.js
+++ b/components/Modal/CreateBlueprint.js
@@ -34,7 +34,7 @@ class CreateBlueprint extends React.Component {
           onClick={this.open}
           disabled={this.props.disabled}
         >
-          <FormattedMessage defaultMessage="Create Blueprint" />
+          <FormattedMessage defaultMessage="Create blueprint" />
         </button>
         {this.state.showModal && (
           <CreateBlueprintModal
@@ -155,7 +155,7 @@ class CreateBlueprintModal extends React.Component {
         <Modal.Header>
           <Modal.CloseButton onClick={this.props.close} />
           <Modal.Title>
-            <FormattedMessage defaultMessage="Create Blueprint" />
+            <FormattedMessage defaultMessage="Create blueprint" />
           </Modal.Title>
         </Modal.Header>
         <Modal.Body>

--- a/components/Modal/DeleteBlueprint.js
+++ b/components/Modal/DeleteBlueprint.js
@@ -39,7 +39,7 @@ class DeleteBlueprint extends React.Component {
           <Modal.Header>
             <Modal.CloseButton onClick={this.close} />
             <Modal.Title>
-              <FormattedMessage defaultMessage="Delete Blueprint" />
+              <FormattedMessage defaultMessage="Delete blueprint" />
             </Modal.Title>
           </Modal.Header>
           <Modal.Body>

--- a/components/Modal/DeleteImage.js
+++ b/components/Modal/DeleteImage.js
@@ -39,7 +39,7 @@ class DeleteImage extends React.Component {
                 <span className="pficon pficon-close" />
               </button>
               <h4 className="modal-title" id="myModalLabel">
-                <FormattedMessage defaultMessage="Delete Image" />
+                <FormattedMessage defaultMessage="Delete image" />
               </h4>
             </div>
             <div className="modal-body">
@@ -58,7 +58,7 @@ class DeleteImage extends React.Component {
                 <FormattedMessage defaultMessage="Cancel" />
               </button>
               <button type="button" className="btn btn-danger" data-dismiss="modal" onClick={this.handleDelete}>
-                <FormattedMessage defaultMessage="Delete Image" />
+                <FormattedMessage defaultMessage="Delete image" />
               </button>
             </div>
           </div>

--- a/components/Modal/EditDescription.js
+++ b/components/Modal/EditDescription.js
@@ -75,7 +75,7 @@ class EditDescriptionModal extends React.Component {
         <Modal.Header>
           <Modal.CloseButton onClick={this.props.close} />
           <Modal.Title>
-            <FormattedMessage defaultMessage="Edit Description" />
+            <FormattedMessage defaultMessage="Edit description" />
           </Modal.Title>
         </Modal.Header>
         <Modal.Body>

--- a/components/Modal/ExportBlueprint.js
+++ b/components/Modal/ExportBlueprint.js
@@ -47,7 +47,7 @@ class ExportBlueprint extends React.Component {
           <Modal.Header>
             <Modal.CloseButton onClick={this.close} />
             <Modal.Title id="title-export">
-              <FormattedMessage defaultMessage="Export Blueprint" />
+              <FormattedMessage defaultMessage="Export blueprint" />
             </Modal.Title>
           </Modal.Header>
           <Modal.Body>

--- a/components/Modal/ManageSources.js
+++ b/components/Modal/ManageSources.js
@@ -22,7 +22,7 @@ const messages = defineMessages({
       "otherwise resolving dependencies and composing images will fail.",
   },
   errorStateTitle: {
-    defaultMessage: "An Error Occurred",
+    defaultMessage: "An error occurred",
   },
   errorStateMessage: {
     defaultMessage: "An error occurred while trying to get sources.",
@@ -64,13 +64,13 @@ const messages = defineMessages({
     defaultMessage: "metalink",
   },
   add: {
-    defaultMessage: "Add Source",
+    defaultMessage: "Add source",
   },
   save: {
-    defaultMessage: "Add Source",
+    defaultMessage: "Add source",
   },
   update: {
-    defaultMessage: "Update Source",
+    defaultMessage: "Update source",
   },
   cancel: {
     defaultMessage: "Cancel",
@@ -100,7 +100,7 @@ class ManageSources extends React.Component {
       <>
         <a href="#" onClick={!this.props.disabled ? this.open : undefined}>
           <FormattedMessage
-            defaultMessage="Manage Sources"
+            defaultMessage="Manage sources"
             description="User action for displaying the list of source repositories"
           />
         </a>
@@ -373,8 +373,8 @@ class ManageSourcesModal extends React.Component {
                 description="Sources provide the contents from which components are selected"
               />
             )) ||
-              (this.state.editName === "" && <FormattedMessage defaultMessage="Add Source" />) || (
-                <FormattedMessage defaultMessage="Edit Source" />
+              (this.state.editName === "" && <FormattedMessage defaultMessage="Add source" />) || (
+                <FormattedMessage defaultMessage="Edit source" />
               )}
           </Modal.Title>
         </Modal.Header>

--- a/components/Modal/PendingChanges.js
+++ b/components/Modal/PendingChanges.js
@@ -77,7 +77,7 @@ class PendingChanges extends React.Component {
                 <span className="pficon pficon-close" />
               </button>
               <h4 className="modal-title" id="myModalLabel">
-                <FormattedMessage defaultMessage="Changes Pending Commit" />
+                <FormattedMessage defaultMessage="Changes pending commit" />
               </h4>
             </div>
             <div className="modal-body">
@@ -115,7 +115,7 @@ class PendingChanges extends React.Component {
                     <FormattedMessage
                       defaultMessage="{heading} {parenthetical}"
                       values={{
-                        heading: <FormattedMessage defaultMessage="Pending Changes" tagName="strong" />,
+                        heading: <FormattedMessage defaultMessage="Pending changes" tagName="strong" />,
                         parenthetical: <span className="text-muted"> {formatMessage(messages.parenthetical)}</span>,
                       }}
                     />

--- a/components/Modal/StopBuild.js
+++ b/components/Modal/StopBuild.js
@@ -41,7 +41,7 @@ class StopBuild extends React.Component {
                 <span className="pficon pficon-close" />
               </button>
               <h4 className="modal-title" id="myModalLabel">
-                <FormattedMessage defaultMessage="Stop Build" />
+                <FormattedMessage defaultMessage="Stop build" />
               </h4>
             </div>
             <div className="modal-body">
@@ -60,7 +60,7 @@ class StopBuild extends React.Component {
                 <FormattedMessage defaultMessage="Cancel" />
               </button>
               <button type="button" className="btn btn-primary" data-dismiss="modal" onClick={this.handleCancel}>
-                <FormattedMessage defaultMessage="Stop Build" />
+                <FormattedMessage defaultMessage="Stop build" />
               </button>
             </div>
           </div>

--- a/components/Modal/UserAccount.js
+++ b/components/Modal/UserAccount.js
@@ -10,10 +10,10 @@ import { setModalUserAccountData } from "../../core/actions/modals";
 
 const messages = defineMessages({
   modalTitleCreate: {
-    defaultMessage: "Create User Account",
+    defaultMessage: "Create user account",
   },
   modalTitleEdit: {
-    defaultMessage: "Edit User Account",
+    defaultMessage: "Edit user account",
   },
   sshKeyHelp: {
     defaultMessage: "Paste the contents of your public SSH key file here. ",
@@ -317,7 +317,7 @@ class UserAccount extends React.Component {
                           className="btn btn-default"
                           onClick={() => this.setState({ setNewPassword: true })}
                         >
-                          <FormattedMessage defaultMessage="Set Password" />
+                          <FormattedMessage defaultMessage="Set password" />
                         </button>
                       </div>
                     </div>
@@ -338,7 +338,7 @@ class UserAccount extends React.Component {
                                 className="btn btn-default"
                                 onClick={() => this.setState({ setNewPassword: true })}
                               >
-                                <FormattedMessage defaultMessage="Set New Password" />
+                                <FormattedMessage defaultMessage="Set new password" />
                               </button>
 
                               <button
@@ -346,7 +346,7 @@ class UserAccount extends React.Component {
                                 className="btn btn-default"
                                 onClick={() => this.handleRemovePassword()}
                               >
-                                <FormattedMessage defaultMessage="Remove Password" />
+                                <FormattedMessage defaultMessage="Remove password" />
                               </button>
                             </div>
                           )}

--- a/components/Toolbar/FilterInput.js
+++ b/components/Toolbar/FilterInput.js
@@ -8,19 +8,19 @@ const messages = defineMessages({
     defaultMessage: "Name",
   },
   filterNamePlaceholder: {
-    defaultMessage: "Filter by Name",
+    defaultMessage: "Filter by name",
   },
   filterReleaseTitle: {
     defaultMessage: "Release",
   },
   filterReleasePlaceholder: {
-    defaultMessage: "Filter by Release",
+    defaultMessage: "Filter by release",
   },
   filterVersionTitle: {
     defaultMessage: "Version",
   },
   filterVersionPlaceholder: {
-    defaultMessage: "Filter by Version",
+    defaultMessage: "Filter by version",
   },
 });
 

--- a/components/Toolbar/ToolbarLayout.js
+++ b/components/Toolbar/ToolbarLayout.js
@@ -61,11 +61,11 @@ class ToolbarLayout extends React.Component {
           {filters.filterValues && filters.filterValues.length !== 0 && (
             <Toolbar.Results>
               <Filter.ActiveLabel>
-                <FormattedMessage defaultMessage="Active Filters" />:
+                <FormattedMessage defaultMessage="Active filters" />:
               </Filter.ActiveLabel>
               <Filter.List>{filters.filterValues.map((filter) => filterItem(filter))}</Filter.List>
               <button type="button" className="btn-link" onClick={filterClearValues}>
-                <FormattedMessage defaultMessage="Clear All Filters" />
+                <FormattedMessage defaultMessage="Clear all filters" />
               </button>
             </Toolbar.Results>
           )}

--- a/core/store.js
+++ b/core/store.js
@@ -109,7 +109,7 @@ const initialState = {
         {
           id: "name",
           title: "Name",
-          placeholder: "Filter by Name",
+          placeholder: "Filter by name",
           filterType: "text",
         },
       ],
@@ -121,19 +121,19 @@ const initialState = {
         {
           id: "name",
           title: "Name",
-          placeholder: "Filter by Name",
+          placeholder: "Filter by name",
           filterType: "text",
         },
         {
           id: "version",
           title: "Version",
-          placeholder: "Filter by Version",
+          placeholder: "Filter by version",
           filterType: "text",
         },
         {
           id: "release",
           title: "Release",
-          placeholder: "Filter by Release",
+          placeholder: "Filter by release",
           filterType: "text",
         },
       ],

--- a/pages/blueprint/index.js
+++ b/pages/blueprint/index.js
@@ -77,7 +77,7 @@ const messages = defineMessages({
     defaultMessage: "Blueprint",
   },
   emptyBlueprintTitle: {
-    defaultMessage: "Empty Blueprint",
+    defaultMessage: "Empty blueprint",
   },
   emptyBlueprintMessage: {
     defaultMessage: "There are no components listed in the blueprint. Edit the blueprint to add components.",
@@ -86,7 +86,7 @@ const messages = defineMessages({
     defaultMessage: "Images",
   },
   noImagesTitle: {
-    defaultMessage: "No Images",
+    defaultMessage: "No images",
   },
   noImagesMessage: {
     defaultMessage: "No images have been created from this blueprint.",
@@ -117,13 +117,13 @@ const messages = defineMessages({
     defaultMessage: "If no hostname is provided, the hostname will be determined by the OS.",
   },
   userEdit: {
-    defaultMessage: "Edit User Account",
+    defaultMessage: "Edit user account",
   },
   userKebab: {
-    defaultMessage: "User Account Actions",
+    defaultMessage: "User account actions",
   },
   userDelete: {
-    defaultMessage: "Delete User Account",
+    defaultMessage: "Delete user account",
   },
 });
 
@@ -372,7 +372,7 @@ class BlueprintPage extends React.Component {
           <ol className="breadcrumb">
             <li>
               <Link to="/blueprints">
-                <FormattedMessage defaultMessage="Back to Blueprints" />
+                <FormattedMessage defaultMessage="Back to blueprints" />
               </Link>
             </li>
             <li className="active">
@@ -383,7 +383,7 @@ class BlueprintPage extends React.Component {
             <ul className="list-inline">
               <li>
                 <Link to={`/edit/${this.props.route.params.blueprint}`} className="btn btn-default">
-                  <FormattedMessage defaultMessage="Edit Packages" />
+                  <FormattedMessage defaultMessage="Edit packages" />
                 </Link>
               </li>
               <li>
@@ -476,7 +476,7 @@ class BlueprintPage extends React.Component {
                         </div>
                       )}
                       <button className="btn btn-default" type="button" onClick={this.handleShowModalUserAccount}>
-                        <FormattedMessage defaultMessage="Create User Account" />
+                        <FormattedMessage defaultMessage="Create user account" />
                       </button>
                     </div>
                   </div>
@@ -520,7 +520,7 @@ class BlueprintPage extends React.Component {
                     >
                       <Link to={`/edit/${this.props.route.params.blueprint}`}>
                         <button className="btn btn-default btn-primary" type="button">
-                          <FormattedMessage defaultMessage="Edit Packages" />
+                          <FormattedMessage defaultMessage="Edit packages" />
                         </button>
                       </Link>
                     </EmptyState>
@@ -529,7 +529,7 @@ class BlueprintPage extends React.Component {
               )) || (
                 <div className="col-sm-12 cmpsr-component-details--view">
                   <h3 className="cmpsr-panel__title cmpsr-panel__title--main">
-                    <FormattedMessage defaultMessage="Component Details" />
+                    <FormattedMessage defaultMessage="Component details" />
                   </h3>
                   <ComponentDetailsView
                     blueprint={this.props.route.params.blueprint}

--- a/pages/blueprintEdit/index.js
+++ b/pages/blueprintEdit/index.js
@@ -61,10 +61,10 @@ import "./index.css";
 
 const messages = defineMessages({
   listTitleAvailableComps: {
-    defaultMessage: "Available Components",
+    defaultMessage: "Available components",
   },
   addComponentTitle: {
-    defaultMessage: "Add Blueprint Components",
+    defaultMessage: "Add blueprint components",
   },
   addComponentMessageOne: {
     defaultMessage:
@@ -78,16 +78,16 @@ const messages = defineMessages({
     defaultMessage: "Blueprint",
   },
   filterByLabel: {
-    defaultMessage: "Filter Available Components by Name",
+    defaultMessage: "Filter available components by name",
   },
   filterByPlaceholder: {
-    defaultMessage: "Filter By Name...",
+    defaultMessage: "Filter by name...",
   },
   emptyStateNoResultsMessage: {
     defaultMessage: "Modify your filter criteria to get results.",
   },
   emptyStateNoResultsTitle: {
-    defaultMessage: "No Results Match the Filter Criteria",
+    defaultMessage: "No results match the filter criteria",
   },
   paginationPerPage: {
     defaultMessage: "per page",
@@ -404,7 +404,7 @@ class EditBlueprintPage extends React.Component {
           <ol className="breadcrumb">
             <li>
               <Link to="/blueprints">
-                <FormattedMessage defaultMessage="Back to Blueprints" />
+                <FormattedMessage defaultMessage="Back to blueprints" />
               </Link>
             </li>
             <li>
@@ -412,7 +412,7 @@ class EditBlueprintPage extends React.Component {
             </li>
             <li className="active">
               <strong>
-                <FormattedMessage defaultMessage="Edit Packages" />
+                <FormattedMessage defaultMessage="Edit packages" />
               </strong>
             </li>
           </ol>
@@ -453,13 +453,13 @@ class EditBlueprintPage extends React.Component {
               {(numPendingChanges > 0 && (
                 <li>
                   <button className="btn btn-default" type="button" onClick={this.handleDiscardChanges}>
-                    <FormattedMessage defaultMessage="Discard Changes" />
+                    <FormattedMessage defaultMessage="Discard changes" />
                   </button>
                 </li>
               )) || (
                 <li>
                   <button className="btn btn-default disabled" type="button">
-                    <FormattedMessage defaultMessage="Discard Changes" />
+                    <FormattedMessage defaultMessage="Discard changes" />
                   </button>
                 </li>
               )}
@@ -493,11 +493,11 @@ class EditBlueprintPage extends React.Component {
         </header>
         {(inputs.selectedInput.set === false && (
           <h3 className="cmpsr-panel__title cmpsr-panel__title--main">
-            <FormattedMessage defaultMessage="Blueprint Components" />
+            <FormattedMessage defaultMessage="Blueprint components" />
           </h3>
         )) || (
           <h3 className="cmpsr-panel__title cmpsr-panel__title--main">
-            <FormattedMessage defaultMessage="Component Details" />
+            <FormattedMessage defaultMessage="Component details" />
           </h3>
         )}
         {(inputs.selectedInput.set === false && (
@@ -610,7 +610,7 @@ class EditBlueprintPage extends React.Component {
                     </li>
                     <li>
                       <a href="#" onClick={(e) => this.handleClearFilters(e)}>
-                        <FormattedMessage defaultMessage="Clear All Filters" />
+                        <FormattedMessage defaultMessage="Clear all filters" />
                       </a>
                     </li>
                   </ul>
@@ -651,7 +651,7 @@ class EditBlueprintPage extends React.Component {
                   message={formatMessage(messages.emptyStateNoResultsMessage)}
                 >
                   <button className="btn btn-link" type="button" onClick={(e) => this.handleClearFilters(e)}>
-                    <FormattedMessage defaultMessage="Clear All Filters" />
+                    <FormattedMessage defaultMessage="Clear all filters" />
                   </button>
                 </EmptyState>
               )) ||

--- a/pages/blueprints/index.js
+++ b/pages/blueprints/index.js
@@ -31,16 +31,16 @@ const messages = defineMessages({
       "Images can be produced in a variety of output formats.",
   },
   emptyTitle: {
-    defaultMessage: "No Blueprints",
+    defaultMessage: "No blueprints",
   },
   errorGenericTitle: {
-    defaultMessage: "An Error Occurred",
+    defaultMessage: "An error occurred",
   },
   noResultsMessage: {
     defaultMessage: "Modify your filter criteria to get results.",
   },
   noResultsTitle: {
-    defaultMessage: "No Results Match the Filter Criteria",
+    defaultMessage: "No results match the filter criteria",
   },
 });
 
@@ -129,7 +129,7 @@ class BlueprintsPage extends React.Component {
             >
               <EmptyStatePrimary>
                 <Button variant="link" type="button" onClick={blueprintsFilterClearValues}>
-                  <FormattedMessage defaultMessage="Clear All Filters" />
+                  <FormattedMessage defaultMessage="Clear all filters" />
                 </Button>
               </EmptyStatePrimary>
             </EmptyState>

--- a/pages/error/index.js
+++ b/pages/error/index.js
@@ -10,7 +10,7 @@ const messages = defineMessages({
     defaultMessage: "Error",
   },
   pageNotFoundMessage: {
-    defaultMessage: "Page Not Found",
+    defaultMessage: "Page not found",
   },
   pageNotFoundTitle: {
     defaultMessage: "Page not found",

--- a/test/verify/check-blueprint
+++ b/test/verify/check-blueprint
@@ -92,7 +92,7 @@ class TestBlueprint(composerlib.ComposerCase):
         b.wait_not_present("#httpd-server-name")
         # clear filter
         b.click(".filter-pf-active-label + .list-inline .pficon-close")
-        b.wait_not_present("p:contains('Active Filters:')")
+        b.wait_not_present("p:contains('Active filters:')")
 
         # filter "httpd" will show three matched blueprints
         b.set_input_text("#filter-blueprints", "httpd")
@@ -103,8 +103,8 @@ class TestBlueprint(composerlib.ComposerCase):
         b.wait_visible("#httpd-server-with-hostname-name")
         b.wait_visible("#httpd-server-with-user-name")
         # clear filter
-        b.click("button:contains('Clear All Filters')")
-        b.wait_not_present("p:contains('Active Filters:')")
+        b.click("button:contains('Clear all filters')")
+        b.wait_not_present("p:contains('Active filters:')")
 
         # collect code coverage result
         self.check_coverage()

--- a/test/verify/check-custom
+++ b/test/verify/check-custom
@@ -168,7 +168,7 @@ class TestCustom(composerlib.ComposerCase):
             b.click("#blueprint-tabs-tab-customizations")
 
         # add a new user
-        b.click("button:contains('Create User Account')")
+        b.click("button:contains('Create user account')")
         b.wait_visible("#cmpsr-modal-user-account")
         set_input_value("#textInput2-modal-user", "x y")
         b.wait_val("#textInput1-modal-user", "xy")
@@ -205,9 +205,9 @@ class TestCustom(composerlib.ComposerCase):
 
         # update password
         new_password = "c456rty$%^RTY"
-        b.click("button[aria-label='Edit User Account xy']")
+        b.click("button[aria-label='Edit user account xy']")
         b.wait_visible("#cmpsr-modal-user-account")
-        b.click("button:contains('Set New Password')")
+        b.click("button:contains('Set new password')")
         set_input_value("#textInput1-modal-password", new_password)
         set_input_value("#textInput2-modal-password", new_password)
         b.click("#cmpsr-modal-user-account button:contains('Update')")
@@ -221,16 +221,16 @@ class TestCustom(composerlib.ComposerCase):
         self.assertEqual(passwd_str, passwd_crypt)
 
         # remove password
-        b.click("button[aria-label='Edit User Account xy']")
+        b.click("button[aria-label='Edit user account xy']")
         b.wait_visible("#cmpsr-modal-user-account")
-        b.click("button:contains('Remove Password')")
+        b.click("button:contains('Remove password')")
         b.click("#cmpsr-modal-user-account button:contains('Update')")
         b.wait_not_present("#cmpsr-modal-user-account")
         b.wait_visible("tr td[data-label=Password]")
         b.wait_not_present("tr td[data-label=Password] .fa-check")
 
         # duplicated user
-        b.click("button:contains('Create User Account')")
+        b.click("button:contains('Create user account')")
         b.wait_visible("#cmpsr-modal-user-account")
         set_input_value("#textInput2-modal-user", "x y")
         b.wait_val("#textInput1-modal-user", "xy")
@@ -239,7 +239,7 @@ class TestCustom(composerlib.ComposerCase):
         b.wait_not_present("#cmpsr-modal-user-account")
 
         # password checking error
-        b.click("button:contains('Create User Account')")
+        b.click("button:contains('Create user account')")
         b.wait_visible("#cmpsr-modal-user-account")
         set_input_value("#textInput2-modal-user", "admin user")
         b.wait_val("#textInput1-modal-user", "auser")
@@ -252,10 +252,10 @@ class TestCustom(composerlib.ComposerCase):
         b.wait_not_present("#cmpsr-modal-user-account")
 
         # delete user
-        delete_drop_down_sel = "button[aria-label='User Account Actions xy']"
+        delete_drop_down_sel = "button[aria-label='User account actions xy']"
         b.click(delete_drop_down_sel)
         b.wait_attr(delete_drop_down_sel, "aria-expanded", "true")
-        b.click("a:contains('Delete User Account')")
+        b.click("a:contains('Delete user account')")
         b.wait_not_present("table")
 
         # collect code coverage result

--- a/test/verify/check-dependence
+++ b/test/verify/check-dependence
@@ -18,9 +18,9 @@ class TestDependence(composerlib.ComposerCase):
         b.wait_visible("#main")
 
         # go to edit package page
-        b.click("li[data-blueprint=openssh-server] a:contains('Edit Packages')")
+        b.click("li[data-blueprint=openssh-server] a:contains('Edit packages')")
         with b.wait_timeout(120):
-            b.wait_visible("ul[aria-label='Available Components'] li:nth-child(1)")
+            b.wait_visible("ul[aria-label='Available components'] li:nth-child(1)")
 
         # open component detail
         b.click("#openssh-server-toggle")
@@ -31,9 +31,9 @@ class TestDependence(composerlib.ComposerCase):
         # with b.wait_timeout(480):
         #     b.wait_visible(".cc-component-summary__deps")
         # # show all
-        # b.click("button:contains('Show All')")
+        # b.click("button:contains('Show all')")
         # # show less
-        # b.click("button:contains('Show Less')")
+        # b.click("button:contains('Show less')")
         # close detail
         b.click("#openssh-server-toggle")
         b.wait_not_visible("#openssh-server-details")
@@ -52,9 +52,9 @@ class TestDependence(composerlib.ComposerCase):
         b.wait_visible("#main")
 
         # go to edit package page
-        b.click("li[data-blueprint=openssh-server] a:contains('Edit Packages')")
+        b.click("li[data-blueprint=openssh-server] a:contains('Edit packages')")
         with b.wait_timeout(120):
-            b.wait_visible("ul[aria-label='Available Components'] li:nth-child(1)")
+            b.wait_visible("ul[aria-label='Available components'] li:nth-child(1)")
 
         # view openssh-server package detail
         b.click("#openssh-server-kebab")
@@ -64,7 +64,7 @@ class TestDependence(composerlib.ComposerCase):
         b.set_val("#cmpsr-compon__version-select", "1")
         b.wait_val("#cmpsr-compon__version-select", "1")
         # group actions end
-        b.click("button:contains('Apply Change')")
+        b.click("button:contains('Apply change')")
         b.wait_visible("a:contains('1 Pending Change')")
 
         # search for openssh-server pacakge

--- a/test/verify/check-image
+++ b/test/verify/check-image
@@ -408,7 +408,7 @@ class TestImage(composerlib.ComposerCase):
         b.wait_attr("#{}-actions".format(uuid), "aria-expanded", "true")
         b.click("li[aria-labelledby={}] a:contains('Delete')".format(selector))
         b.wait_attr("#{}-actions".format(uuid), "aria-expanded", "false")
-        b.click("#cmpsr-modal-delete button:contains('Delete Image')")
+        b.click("#cmpsr-modal-delete button:contains('Delete image')")
         b.wait_not_present("#{}".format(selector))
 
         # collect code coverage result
@@ -485,7 +485,7 @@ class TestImage(composerlib.ComposerCase):
         b.wait_attr("#{}-actions".format(uuid), "aria-expanded", "true")
         b.click("li[aria-labelledby={}] a:contains('Delete')".format(selector))
         b.wait_attr("#{}-actions".format(uuid), "aria-expanded", "false")
-        b.click("#cmpsr-modal-delete button:contains('Delete Image')")
+        b.click("#cmpsr-modal-delete button:contains('Delete image')")
         b.wait_not_present("#{}".format(selector))
         self.allow_journal_messages(".*avc:  denied.*",
                                     ".*audit: .*seresult=denied .*")
@@ -530,7 +530,7 @@ class TestImage(composerlib.ComposerCase):
         b.wait_attr("#{}-actions".format(uuid), "aria-expanded", "true")
         b.click("li[aria-labelledby={}] a:contains('Stop')".format(selector))
         b.wait_attr("#{}-actions".format(uuid), "aria-expanded", "false")
-        b.click("#cmpsr-modal-delete button:contains('Stop Build')")
+        b.click("#cmpsr-modal-delete button:contains('Stop build')")
         b.wait_not_present("#cmpsr-modal-delete")
         # delete canceled image build
         b.click("#{}-actions".format(uuid))

--- a/test/verify/check-package
+++ b/test/verify/check-package
@@ -20,15 +20,15 @@ class TestPackage(composerlib.ComposerCase):
         b.wait_visible("#main")
 
         # go to edit package page
-        b.click("li[data-blueprint=httpd-server] a:contains('Edit Packages')")
+        b.click("li[data-blueprint=httpd-server] a:contains('Edit packages')")
         with b.wait_timeout(120):
-            b.wait_visible("ul[aria-label='Available Components'] li:nth-child(1)")
+            b.wait_visible("ul[aria-label='Available components'] li:nth-child(1)")
 
         # do navigate with > and < button
         b.click("button[aria-label='Go to next page']")
-        b.wait_visible("ul[aria-label='Available Components'] li:nth-child(1)")
+        b.wait_visible("ul[aria-label='Available components'] li:nth-child(1)")
         b.click("button[aria-label='Go to previous page']")
-        b.wait_visible("ul[aria-label='Available Components'] li:nth-child(1)")
+        b.wait_visible("ul[aria-label='Available components'] li:nth-child(1)")
         # filter on avaliable components
         b.set_input_text("#cmpsr-blueprint-input-filter", "cockpit-bridge")
         b.key_press("\r")
@@ -36,8 +36,8 @@ class TestPackage(composerlib.ComposerCase):
             b.wait_text("#cockpit-bridge-input", "cockpit-bridge")
         b.wait_visible(".toolbar-pf-results .label-info > span")
         # click Clear All Filters link
-        b.click("span:contains('Clear All Filters')")
-        b.wait_visible("ul[aria-label='Available Components'] li:nth-child(1)")
+        b.click("span:contains('Clear all filters')")
+        b.wait_visible("ul[aria-label='Available components'] li:nth-child(1)")
         b.wait_not_present(".toolbar-pf-results .label-info span")
         b.wait_not_present("#cockpit-bridge-input")
 
@@ -46,7 +46,7 @@ class TestPackage(composerlib.ComposerCase):
         b.set_input_text("#filter-blueprints", "tmux")
         b.key_press("\r")
         b.wait_text("ul[data-list=components] li:nth-child(1) #tmux", "tmux")
-        b.click(".cmpsr-panel__body--main .toolbar-pf-results button:contains('Clear All Filters')")
+        b.click(".cmpsr-panel__body--main .toolbar-pf-results button:contains('Clear all filters')")
         b.wait_text("ul[data-list=components] li:nth-child(1) #httpd", "httpd")
         # filter by version
         b.click("#filterFieldTypeMenu")
@@ -83,9 +83,9 @@ class TestPackage(composerlib.ComposerCase):
         b.wait_visible("#main")
 
         # go to edit package page
-        b.click("li[data-blueprint=httpd-server] a:contains('Edit Packages')")
+        b.click("li[data-blueprint=httpd-server] a:contains('Edit packages')")
         with b.wait_timeout(120):
-            b.wait_visible("ul[aria-label='Available Components'] li:nth-child(1)")
+            b.wait_visible("ul[aria-label='Available components'] li:nth-child(1)")
 
         blueprint_list = [
             "httpd",
@@ -93,18 +93,18 @@ class TestPackage(composerlib.ComposerCase):
             "vim-enhanced"
         ]
         # sort from Z-A
-        b.wait_visible("ul[aria-label='Selected Components']")
+        b.wait_visible("ul[aria-label='Selected components']")
         b.click(".fa-sort-alpha-asc")
         b.wait_visible(".fa-sort-alpha-desc")
         for i, v in enumerate(sorted(blueprint_list, reverse=True)):
-            b.wait_text("ul[aria-label='Selected Components'] li:nth-child({}) "
+            b.wait_text("ul[aria-label='Selected components'] li:nth-child({}) "
                         "a strong".format(i + 1), v)
 
         # sort from A-Z
         b.click(".fa-sort-alpha-desc")
         b.wait_visible(".fa-sort-alpha-asc")
         for i, v in enumerate(sorted(blueprint_list)):
-            b.wait_text("ul[aria-label='Selected Components'] li:nth-child({}) "
+            b.wait_text("ul[aria-label='Selected components'] li:nth-child({}) "
                         "a strong".format(i + 1), v)
 
         # collect code coverage result
@@ -117,9 +117,9 @@ class TestPackage(composerlib.ComposerCase):
         b.wait_visible("#main")
 
         # go to edit package page
-        b.click("li[data-blueprint=openssh-server] a:contains('Edit Packages')")
+        b.click("li[data-blueprint=openssh-server] a:contains('Edit packages')")
         with b.wait_timeout(120):
-            b.wait_visible("ul[aria-label='Available Components'] li:nth-child(1)")
+            b.wait_visible("ul[aria-label='Available components'] li:nth-child(1)")
 
         # search for openssh-server pacakge
         b.set_input_text("#cmpsr-blueprint-input-filter", "cockpit-bridge")
@@ -164,7 +164,7 @@ class TestPackage(composerlib.ComposerCase):
         # logout and login, still in edit blueprint page
         with b.wait_timeout(300):
             b.relogin("/composer", superuser=True)
-        b.wait_visible("ul[aria-label='Available Components'] li:nth-child(1)")
+        b.wait_visible("ul[aria-label='Available components'] li:nth-child(1)")
 
         # "1 Pending Change" still there
         b.wait_visible("a:contains('1 Pending Change')")
@@ -204,9 +204,9 @@ class TestPackage(composerlib.ComposerCase):
         b.wait_visible("#main")
 
         # go to edit package page
-        b.click("li[data-blueprint=openssh-server] a:contains('Edit Packages')")
+        b.click("li[data-blueprint=openssh-server] a:contains('Edit packages')")
         with b.wait_timeout(240):
-            b.wait_visible("ul[aria-label='Available Components'] li:nth-child(1)")
+            b.wait_visible("ul[aria-label='Available components'] li:nth-child(1)")
 
         # search for openssh-server pacakge
         b.set_input_text("#cmpsr-blueprint-input-filter", "cockpit-composer")
@@ -218,7 +218,7 @@ class TestPackage(composerlib.ComposerCase):
         # wait for package added
         b.wait_visible("li[data-component=cockpit-composer]")
         # click discard changes button
-        b.click("button:contains('Discard Changes')")
+        b.click("button:contains('Discard changes')")
         b.wait_not_present("li[data-component=cockpit-composer]")
 
         # collect code coverage result

--- a/test/verify/check-service
+++ b/test/verify/check-service
@@ -39,15 +39,15 @@ class TestService(composerlib.ComposerCase):
         # start and enable osbuild-composer from UI
         b.click("button:contains('Start')")
         # work around .pf-c-empty-state element disappear in one second
-        b.wait_in_text("#main", "No Blueprints")
-        b.wait_text(".pf-c-empty-state__content .pf-c-title", "No Blueprints")
+        b.wait_in_text("#main", "No blueprints")
+        b.wait_text(".pf-c-empty-state__content .pf-c-title", "No blueprints")
 
         # create blueprint with random name and description
         name_template = string.ascii_letters + string.digits + "-" + "_"
         bp_name = "".join(random.sample(name_template, 20))
         desc_template = string.ascii_letters + string.digits + " "
         bp_desc = "".join(random.sample(desc_template, 40))
-        b.click(".pf-c-empty-state button:contains('Create Blueprint')")
+        b.click(".pf-c-empty-state button:contains('Create blueprint')")
         b.wait_visible("div[role=dialog] #cmpsr-modal-crt-blueprint")
         # blueprint name
         b.set_input_text("#textInput-modal-markup", bp_name)
@@ -83,7 +83,7 @@ class TestService(composerlib.ComposerCase):
         b.wait_not_present("#cmpsr-toast-committed .pficon-ok")
 
         # click back to blueprint link
-        b.click("a:contains('Back to Blueprints')")
+        b.click("a:contains('Back to blueprints')")
 
         # new added blueprint should be there with correct name and description
         b.wait_visible("li[data-blueprint={}]".format(bp_name))
@@ -106,7 +106,7 @@ class TestService(composerlib.ComposerCase):
         b.wait_not_present("#cmpsr-modal-delete")
         b.wait_not_present("li[data-blueprint={}]".format(bp_name))
         # no blueprint here
-        b.wait_in_text("#main", "No Blueprints")
+        b.wait_in_text("#main", "No blueprints")
 
         # collect code coverage result
         self.check_coverage()
@@ -128,8 +128,8 @@ class TestService(composerlib.ComposerCase):
         # start and enable osbuild-composer from UI
         b.click("button:contains('Start')")
         # work around .pf-c-empty-state element disappear in one second
-        b.wait_in_text("#main", "No Blueprints")
-        b.wait_text(".pf-c-empty-state__content .pf-c-title", "No Blueprints")
+        b.wait_in_text("#main", "No blueprints")
+        b.wait_text(".pf-c-empty-state__content .pf-c-title", "No blueprints")
         # osbuild-composer should be disabled
         is_enabled = m.execute("systemctl is-enabled osbuild-composer.socket || true").rstrip()
         self.assertEqual(is_enabled, "disabled")

--- a/test/verify/check-source
+++ b/test/verify/check-source
@@ -27,7 +27,7 @@ class TestSource(composerlib.ComposerCase):
         drop_down_sel = ".toolbar-pf-action-right #dropdownKebab"
         b.click(drop_down_sel)
         b.wait_attr(drop_down_sel, "aria-expanded", "true")
-        b.click("a:contains('Manage Sources')")
+        b.click("a:contains('Manage sources')")
         b.wait_attr(drop_down_sel, "aria-expanded", "false")
         b.wait_visible("#cmpsr-modal-manage-sources")
 
@@ -37,21 +37,21 @@ class TestSource(composerlib.ComposerCase):
             b.wait_visible("div[data-source={}]".format(source))
 
         # add new source
-        b.click("input[value='Add Source']")
+        b.click("input[value='Add source']")
 
         # can't add srouce if type is empty
         b.set_input_text("#textInput1-modal-source", repo_name)
         b.set_input_text("#textInput2-modal-source", repo_url)
-        b.wait_attr("button:contains('Add Source')", "disabled", "")
+        b.wait_attr("button:contains('Add source')", "disabled", "")
         b.click("button:contains('Cancel')")
         # new source
-        b.click("input[value='Add Source']")
+        b.click("input[value='Add source']")
         b.set_input_text("#textInput1-modal-source", repo_name)
         b.set_input_text("#textInput2-modal-source", repo_url)
         b.set_val("#textInput3-modal-source", "yum-baseurl")
         b.wait_val("#textInput3-modal-source", "yum-baseurl")
         # groups action done
-        b.click("button:contains('Add Source')")
+        b.click("button:contains('Add source')")
 
         # HACK: workaround issue https://github.com/osbuild/cockpit-composer/issues/989
         # open manage source again to continue running test
@@ -60,21 +60,21 @@ class TestSource(composerlib.ComposerCase):
             b.wait_not_present("#cmpsr-modal-manage-sources")
             b.click(drop_down_sel)
             b.wait_attr(drop_down_sel, "aria-expanded", "true")
-            b.click("a:contains('Manage Sources')")
+            b.click("a:contains('Manage sources')")
             b.wait_attr(drop_down_sel, "aria-expanded", "false")
             b.wait_visible("#cmpsr-modal-manage-sources")
 
         # endit new source to enable check SSL certificate and GPG key
-        b.click("button[aria-label='Edit Source {}']".format(repo_name))
+        b.click("button[aria-label='Edit source {}']".format(repo_name))
         # SSL certificate
         b.click("#checkboxInput4-modal-source")
         # GPG key
         b.click("#checkboxInput5-modal-source")
-        b.click("button:contains('Update Source')")
+        b.click("button:contains('Update source')")
 
         # package from new added repo is here already
         b.click("button:contains('Close')")
-        b.click("li[data-blueprint=openssh-server] a:contains('Edit Packages')")
+        b.click("li[data-blueprint=openssh-server] a:contains('Edit packages')")
         # wait for all available compontents visible
         with b.wait_timeout(300):
             b.wait_visible("ul[data-list=inputs]")
@@ -85,25 +85,25 @@ class TestSource(composerlib.ComposerCase):
             b.wait_text("#kanshi-input", "kanshi")
         # new added reop works, go back
         # click back to blueprint link
-        b.click("a:contains('Back to Blueprints')")
+        b.click("a:contains('Back to blueprints')")
         # go to manage source
         b.click(drop_down_sel)
         b.wait_attr(drop_down_sel, "aria-expanded", "true")
-        b.click("a:contains('Manage Sources')")
+        b.click("a:contains('Manage sources')")
         b.wait_attr(drop_down_sel, "aria-expanded", "false")
         b.wait_visible("#cmpsr-modal-manage-sources")
 
         # duplicated source can't be added
-        b.click("input[value='Add Source']")
+        b.click("input[value='Add source']")
         b.set_input_text("#textInput2-modal-source", repo_url)
         b.wait_text("#textInput2-modal-source-help", "This source path already exists.")
         b.click("button:contains('Cancel')")
 
         # delete added source
-        delete_drop_down_sel = "button[aria-label='Source Actions {}']".format(repo_name)
+        delete_drop_down_sel = "button[aria-label='Source actions {}']".format(repo_name)
         b.click(delete_drop_down_sel)
         b.wait_attr(delete_drop_down_sel, "aria-expanded", "true")
-        b.click("a:contains('Remove Source')")
+        b.click("a:contains('Remove source')")
         b.wait_not_present("div[data-source={}]".format(repo_name))
 
         # close manage source dialog


### PR DESCRIPTION
See https://www.patternfly.org/v4/ux-writing/capitalization

19% of strings were using title case.
This breaks translations, but they will be just fuzzy, so very easy to
fix up by translators. It would be possible to also change `.po` files,
but then we would need to manually fix Weblate. Also I believe that this
is not that big number of strings and gives translators chance to go
through and fix strings properly (as I've seen people translating title
case as title case).

This was done by:
```
make po/cockpit-composer.pot
msggrep --no-wrap --msgid -e '[A-Z].*\s[A-Z]' po/cockpit-composer.pot | grep "^msgid " | cut -d " " -f2- | sort --reverse > titles
<manually reviewing strings in titles and removing the ones, that don't apply>
<copying "tools/title2sentence.py" from cockpit-project/cockpit>
./title2sentence.py -i titles -o f.sh
<changing the first line of f.sh to "git ls-files | xargs sed -i \ ">
chmod u+x f.sh
./f.sh
git checkout -- po/*.po
git add -u
```