### PR TITLE
test: disable worker socket on all distros

### DIFF
--- a/test/verify/check-service
+++ b/test/verify/check-service
@@ -3,7 +3,6 @@
 # checkpoint:
 # 1. osbuild-composer.socket can be started and enabled
 # 2. no blueprint by default and can add and delete blueprint
-import os
 import string
 import random
 
@@ -19,16 +18,13 @@ class TestService(composerlib.ComposerCase):
         # stop and disable osbuild-composer.socket service
         super().setUp()
         m = self.machine
-        distro = os.environ.get("TEST_OS")
 
         m.execute("""
             for bp in $(composer-cli blueprints list); do
                 composer-cli blueprints delete $bp
             done
-            systemctl disable --now osbuild-composer.socket osbuild-composer.service
+            systemctl disable --now osbuild-composer.socket osbuild-composer.service osbuild-local-worker.socket
         """)
-        if (distro == "fedora-32" or distro == "fedora-33"):
-            m.execute("systemctl disable --now osbuild-local-worker.socket")
 
     def testBasic(self):
         b = self.browser
@@ -114,11 +110,6 @@ class TestService(composerlib.ComposerCase):
     def testNoEnable(self):
         b = self.browser
         m = self.machine
-        distro = os.environ.get("TEST_OS")
-        # stop and disable the osbuild-composer service and sockets
-        m.execute("systemctl disable --now osbuild-composer.socket osbuild-composer.service")
-        if (distro == "fedora-32" or distro == "fedora-33"):
-            m.execute("systemctl disable --now osbuild-local-worker.socket")
 
         self.login_and_go("/composer", superuser=True)
         b.wait_visible("#main")
@@ -142,12 +133,6 @@ class TestService(composerlib.ComposerCase):
 
     def testNonAdminUser(self):
         b = self.browser
-        m = self.machine
-        distro = os.environ.get("TEST_OS")
-        # stop and disable the osbuild-composer service and sockets
-        m.execute("systemctl disable --now osbuild-composer.socket osbuild-composer.service")
-        if (distro == "fedora-32" or distro == "fedora-33"):
-            m.execute("systemctl disable --now osbuild-local-worker.socket")
 
         self.login_and_go("/composer", superuser=False)
         b.wait_visible("#main")

--- a/test/verify/composerlib.py
+++ b/test/verify/composerlib.py
@@ -28,8 +28,6 @@ class ComposerCase(testlib.MachineCase):
     def setUp(self):
         super().setUp(restrict=False)
 
-        distro = os.environ.get("TEST_OS")
-
         self.allow_journal_messages(*allowed_journal_messages)
         self.allow_browser_errors(*allowed_browser_errors)
 
@@ -38,11 +36,9 @@ class ComposerCase(testlib.MachineCase):
 
         # re-start osbuild-composer.socket
         self.machine.execute(script="""#!/bin/sh
-        systemctl stop --quiet osbuild-composer.socket osbuild-composer.service
+        systemctl stop --quiet osbuild-composer.socket osbuild-composer.service osbuild-local-worker.socket
         systemctl start osbuild-composer.socket
         """)
-        if (distro == "fedora-32" or distro == "fedora-33"):
-            self.machine.execute("systemctl disable --now osbuild-local-worker.socket")
 
         # push pre-defined blueprint
         self.machine.execute(script="""#!/bin/sh


### PR DESCRIPTION
We do not test against/release in any distros that do not contain osbuild-composer v25 which includes support for local workers. In order to completely disable osbuild-composer the worker socket needs to be disabled alongside the osbuild-composer service and weldr api socket. These are now disabled on all distros not just fedora 32 and 33.