### PR TITLE
workflows: Move actions to Ubuntu 20.04

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   coverity:
     name: "Test Suite"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: cockpit-composer

--- a/.github/workflows/npm-update.yml
+++ b/.github/workflows/npm-update.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   npm-update:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Set up dependencies
         run: |

--- a/.github/workflows/po-refresh.yml
+++ b/.github/workflows/po-refresh.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 jobs:
   po-refresh:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Set up dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - '[0-9]*'
 jobs:
   cockpituous:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container:
       image: ghcr.io/cockpit-project/release
     steps:


### PR DESCRIPTION
GitHub's 18.04 additional repositories break NPM. As "ubuntu-latest" is
going to switch to 20.04 soon anyway [1], do the jump now.

[1] https://github.com/actions/virtual-environments/issues/1816

If you look into `Actions` tab, all actions were failing for some time now.