### PR TITLE
Rhel8 rebase

### DIFF
--- a/test/verify/check-source
+++ b/test/verify/check-source
@@ -63,7 +63,7 @@ class TestSource(composerlib.ComposerCase):
         # open manage source again to continue running test
         if b.cdp.browser == "firefox":
             # open manage sources dialog
-            drop_down_sel = ".toolbar-pf-action-right #dropdownKebab"
+            b.wait_not_present("#cmpsr-modal-manage-sources")
             b.click(drop_down_sel)
             b.wait_attr(drop_down_sel, "aria-expanded", "true")
             b.click("a:contains('Manage Sources')")


### PR DESCRIPTION
Rebase one commit(test: fix TestSource modal reload issue) from master to fix [check_source issue](https://logs.cockpit-project.org/logs/pull-1527-20210114-181122-84bf7018-rhel-8-3-firefox-osbuild-cockpit-composer-rhel-8/log.html#22-2) on `rhel-8` branch.