### PR TITLE
[rhel-8] test: Fix check package release issue

### DIFF
--- a/test/verify/check-package
+++ b/test/verify/check-package
@@ -71,7 +71,8 @@ class TestPackage(composerlib.ComposerCase):
         release = b.text("li[data-component=tmux] .cc-component__release strong")
         b.set_input_text("#filter-blueprints", release)
         b.key_press("\r")
-        b.wait_text("ul[data-list=components] li:nth-child(1) #tmux", "tmux")
+        b.wait_text("ul[data-list=components] li:nth-child(1) .cc-component__release strong",
+                    release)
         b.click(".cmpsr-panel__body--main .toolbar-pf-results .pficon-close")
         b.wait_text("ul[data-list=components] li:nth-child(1) #httpd", "httpd")
 


### PR DESCRIPTION
Test should check release field when filter package by release, not
package name

Cherry-picked from master commit 7b416df4dd06

-----

 - [ ] Needs some more backports: PR #1221 

This is a nice and unintrusive test stabilization for the RHEL 8 branch. But I mostly want a PR for running tests against rhel-8-4 now, as deadlines for 8.3.1 have passed. So let's switch over to 8.4 ASAP.