### PR TITLE
utils: Rename Fedora rawhide branch in cockpituous control file

### DIFF
--- a/utils/cockpituous-release
+++ b/utils/cockpituous-release
@@ -16,7 +16,7 @@ job release-source
 job release-srpm -V
 
 # Do fedora builds for the tag, using tarball
-job release-koji master
+job release-koji rawhide
 job release-koji f32
 job release-koji f33 
 


### PR DESCRIPTION
Fedora "master" branches were renamed to "rawhide" recently.