### PR TITLE
Wizard: temporarily disable uploading to vmware.

### DIFF
--- a/components/Wizard/ImageStep.js
+++ b/components/Wizard/ImageStep.js
@@ -311,6 +311,7 @@ class ImageStep extends React.PureComponent {
       </FormGroup>
     );
 
+    // eslint-disable-next-line no-unused-vars
     const vmwareProviderCheckbox = (
       <FormGroup
         label={<FormattedMessage defaultMessage="Upload image" />}
@@ -506,7 +507,7 @@ class ImageStep extends React.PureComponent {
           </FormGroup>
           {imageType === "ami" && awsProviderCheckbox}
           {imageType === "vhd" && azureProviderCheckbox}
-          {imageType === "vmdk" && vmwareProviderCheckbox}
+          {/* {imageType === "vmdk" && vmwareProviderCheckbox} */}
           {requiresImageSize(imageType) && imageSizeInput}
           {(imageType === "fedora-iot-commit" || imageType === "rhel-edge-commit") && ostreeFields}
         </Form>

--- a/test/verify/check-image
+++ b/test/verify/check-image
@@ -327,6 +327,8 @@ class TestImage(composerlib.ComposerCase):
         # collect code coverage result
         self.check_coverage()
 
+    # temporarily skip until vmware upload is supported
+    @unittest.SkipTest
     def testVMWareStep(self):
         b = self.browser
 


### PR DESCRIPTION
Support for uploading to vmware has not yet landed in osbuild-composer. This patch temporarily removes the upload option.