### PR TITLE
Add support for additional RHEL Edge image types

### DIFF
--- a/components/Wizard/CreateImageUpload.js
+++ b/components/Wizard/CreateImageUpload.js
@@ -64,6 +64,7 @@ class CreateImageUploadModal extends React.Component {
       ostreeSettings: {
         parent: undefined,
         ref: undefined,
+        url: undefined,
       },
       showUploadAwsStep: false,
       showUploadAzureStep: false,
@@ -84,6 +85,7 @@ class CreateImageUploadModal extends React.Component {
     this.setImageType = this.setImageType.bind(this);
     this.setOstreeParent = this.setOstreeParent.bind(this);
     this.setOstreeRef = this.setOstreeRef.bind(this);
+    this.setOstreeURL = this.setOstreeURL.bind(this);
     this.setUploadSettings = this.setUploadSettings.bind(this);
     this.handleUploadService = this.handleUploadService.bind(this);
     this.handleCreateImage = this.handleCreateImage.bind(this);
@@ -211,8 +213,17 @@ class CreateImageUploadModal extends React.Component {
     };
 
     let ostree;
-    if (ostreeSettings.parent !== undefined || ostreeSettings.ref !== undefined) {
-      ostree = ostreeSettings;
+    if (composeType === "fedora-iot-commit" || composeType === "rhel-edge-commit") {
+      ostree = {
+        parent: ostreeSettings.parent,
+        ref: ostreeSettings.ref,
+      };
+    } else if (composeType === "rhel-edge-container") {
+      ostree = {
+        parent: ostreeSettings.parent,
+        ref: ostreeSettings.ref,
+        url: ostreeSettings.url,
+      };
     }
 
     if (uploadService === "") {
@@ -239,6 +250,7 @@ class CreateImageUploadModal extends React.Component {
       ostreeSettings: {
         parent: undefined,
         ref: undefined,
+        url: undefined,
       },
       uploadService: "",
       uploadSettings: {},
@@ -279,6 +291,10 @@ class CreateImageUploadModal extends React.Component {
     this.setState((prevState) => ({ ostreeSettings: { ...prevState.ostreeSettings, ref: value } }));
   }
 
+  setOstreeURL(value) {
+    this.setState((prevState) => ({ ostreeSettings: { ...prevState.ostreeSettings, url: value } }));
+  }
+
   getDefaultImageSize(imageType) {
     if (imageType === "ami") {
       return 6;
@@ -316,7 +332,12 @@ class CreateImageUploadModal extends React.Component {
   }
 
   requiresImageSize(imageType) {
-    if (imageType === "" || imageType === "fedora-iot-commit" || imageType === "rhel-edge-commit") {
+    if (
+      imageType === "" ||
+      imageType === "fedora-iot-commit" ||
+      imageType === "rhel-edge-commit" ||
+      imageType === "rhel-edge-container"
+    ) {
       return false;
     }
     return true;
@@ -366,6 +387,7 @@ class CreateImageUploadModal extends React.Component {
           setImageType={this.setImageType}
           setOstreeParent={this.setOstreeParent}
           setOstreeRef={this.setOstreeRef}
+          setOstreeURL={this.setOstreeURL}
           uploadService={this.state.uploadService}
         />
       ),

--- a/components/Wizard/CreateImageUpload.js
+++ b/components/Wizard/CreateImageUpload.js
@@ -76,6 +76,7 @@ class CreateImageUploadModal extends React.Component {
     this.getDefaultImageSize = this.getDefaultImageSize.bind(this);
     this.isPendingChange = this.isPendingChange.bind(this);
     this.isValidImageSize = this.isValidImageSize.bind(this);
+    this.isValidOstree = this.isValidOstree.bind(this);
     this.isValidOstreeRef = this.isValidOstreeRef.bind(this);
     this.requiresImageSize = this.requiresImageSize.bind(this);
     this.missingRequiredFields = this.missingRequiredFields.bind(this);
@@ -224,6 +225,11 @@ class CreateImageUploadModal extends React.Component {
         ref: ostreeSettings.ref,
         url: ostreeSettings.url,
       };
+    } else if (composeType === "rhel-edge-installer") {
+      ostree = {
+        ref: ostreeSettings.ref,
+        url: ostreeSettings.url,
+      };
     }
 
     if (uploadService === "") {
@@ -313,7 +319,7 @@ class CreateImageUploadModal extends React.Component {
     ) {
       return true;
     }
-    if (!this.isValidOstreeRef(this.state.ostreeSettings.ref)) return true;
+    if (!this.isValidOstree()) return true;
     if (this.missingRequiredFields() && activeStepName === "Review") {
       return true;
     }
@@ -336,7 +342,8 @@ class CreateImageUploadModal extends React.Component {
       imageType === "" ||
       imageType === "fedora-iot-commit" ||
       imageType === "rhel-edge-commit" ||
-      imageType === "rhel-edge-container"
+      imageType === "rhel-edge-container" ||
+      imageType === "rhel-edge-installer"
     ) {
       return false;
     }
@@ -354,6 +361,16 @@ class CreateImageUploadModal extends React.Component {
       return false;
     }
     return true;
+  }
+
+  isValidOstree() {
+    if (
+      this.state.imageType === "rhel-edge-installer" &&
+      (!this.state.ostreeSettings.ref || !this.state.ostreeSettings.url)
+    ) {
+      return false;
+    }
+    return this.isValidOstreeRef(this.state.ostreeSettings.ref);
   }
 
   isValidOstreeRef(ref) {

--- a/components/Wizard/ImageStep.js
+++ b/components/Wizard/ImageStep.js
@@ -57,7 +57,7 @@ const messages = defineMessages({
       "and the forward slash (/). A ref must start with a letter, a number, or an underscore. Slashes must also be followed by a letter or number.",
   },
   requiredField: {
-    defaultMessage: "This is a required field",
+    defaultMessage: "This is a required field.",
   },
   type: {
     defaultMessage: "Type",
@@ -145,9 +145,13 @@ class ImageStep extends React.PureComponent {
   }
 
   handleOSTreeRef(ref) {
-    if (ref === "") {
+    if (ref === "" && this.props.imageType !== "rhel-edge-installer") {
       this.setState({
         ostreeRefValidated: "default",
+      });
+    } else if (ref === "" && this.props.imageType === "rhel-edge-installer") {
+      this.setState({
+        ostreeRefValidated: "error",
       });
     } else if (this.props.isValidOstreeRef(ref)) {
       this.setState({
@@ -573,6 +577,88 @@ class ImageStep extends React.PureComponent {
       </>
     );
 
+    const ostreeInstallerFields = (
+      <>
+        <FormGroup
+          isRequired
+          label={<FormattedMessage defaultMessage="Repository URL" />}
+          labelIcon={
+            <Popover
+              id="ostree-url-popover"
+              bodyContent={
+                <FormattedMessage defaultMessage="Provide the URL of the upstream repository. This repository is where the parent OSTree commit will be pulled from." />
+              }
+              aria-label={formatMessage(ariaLabels.ostreeURL)}
+            >
+              <Button variant="plain" aria-label={formatMessage(ariaLabels.ostreeURL)}>
+                <OutlinedQuestionCircleIcon className="cc-c-text__align-icon" id="popover-icon" />
+              </Button>
+            </Popover>
+          }
+          fieldId="ostree-url-input"
+          helperTextInvalid={formatMessage(messages.requiredField)}
+          validated={ostreeSettings.url !== "" ? "default" : "error"}
+          hasNoPaddingTop
+        >
+          <TextInput
+            className="pf-c-form-control"
+            value={ostreeSettings.url !== undefined ? ostreeSettings.url : ""}
+            type="text"
+            id="ostree-url-input"
+            onChange={setOstreeURL}
+            validated={ostreeSettings.url !== "" ? "default" : "error"}
+          />
+        </FormGroup>
+        <FormGroup
+          isRequired
+          label={<FormattedMessage defaultMessage="Ref" />}
+          labelIcon={
+            <Popover
+              id="ostree-ref-popover"
+              bodyContent={
+                <FormattedMessage defaultMessage="Provide the name of the branch for the content. If the ref does not already exist it will be created." />
+              }
+              aria-label={formatMessage(ariaLabels.ostreeRef)}
+            >
+              <Button variant="plain" aria-label={formatMessage(ariaLabels.ostreeRef)}>
+                <OutlinedQuestionCircleIcon className="cc-c-text__align-icon" id="popover-icon" />
+              </Button>
+            </Popover>
+          }
+          fieldId="ostree-ref-input"
+          helperText={formatMessage(messages.ostreeRefHelperText)}
+          helperTextInvalid={formatMessage(messages.ostreeRefHelperText)}
+          validated={ostreeRefValidated}
+          hasNoPaddingTop
+        >
+          <TextInput
+            className="pf-c-form-control"
+            value={ostreeSettings.ref !== undefined ? ostreeSettings.ref : ""}
+            type="text"
+            id="ostree-ref-input"
+            aria-describedby="ostree-ref-input-helper-default ostree-ref-input-helper"
+            onChange={this.handleOSTreeRef}
+            validated={ostreeRefValidated}
+          />
+          {ostreeRefValidated === "default" && imageType === "rhel-edge-commit" && (
+            <p className="pf-c-form__helper-text" id="ostree-ref-input-helper-default" aria-live="polite">
+              <FormattedMessage
+                defaultMessage="rhel/8/{arch}/edge is the default, where {arch} is determined by the host machine"
+                values={{
+                  arch: <em>$ARCH</em>,
+                }}
+              />
+            </p>
+          )}
+          {ostreeRefValidated === "error" && !ostreeSettings.ref && imageType === "rhel-edge-installer" && (
+            <p className="pf-c-form__helper-text pf-m-error" id="ostree-ref-input-helper-default" aria-live="polite">
+              {formatMessage(messages.requiredField)}
+            </p>
+          )}
+        </FormGroup>
+      </>
+    );
+
     return (
       <>
         {isPendingChange() && (
@@ -617,6 +703,7 @@ class ImageStep extends React.PureComponent {
           {requiresImageSize(imageType) && imageSizeInput}
           {(imageType === "fedora-iot-commit" || imageType === "rhel-edge-commit") && ostreeCommitFields}
           {imageType === "rhel-edge-container" && ostreeContainerFields}
+          {imageType === "rhel-edge-installer" && ostreeInstallerFields}
         </Form>
       </>
     );

--- a/components/Wizard/ImageStep.js
+++ b/components/Wizard/ImageStep.js
@@ -37,6 +37,9 @@ const ariaLabels = defineMessages({
   ostreeRef: {
     defaultMessage: "OSTree ref help",
   },
+  ostreeURL: {
+    defaultMessage: "OSTree repo url help",
+  },
 });
 
 const messages = defineMessages({
@@ -172,6 +175,7 @@ class ImageStep extends React.PureComponent {
       ostreeSettings,
       requiresImageSize,
       setOstreeParent,
+      setOstreeURL,
       uploadService,
     } = this.props;
 
@@ -395,7 +399,7 @@ class ImageStep extends React.PureComponent {
       </FormGroup>
     );
 
-    const ostreeFields = (
+    const ostreeCommitFields = (
       <>
         <FormGroup
           label={<FormattedMessage defaultMessage="Parent commit" />}
@@ -404,6 +408,108 @@ class ImageStep extends React.PureComponent {
               id="ostree-parent-popover"
               bodyContent={
                 <FormattedMessage defaultMessage="Provide the ID of the latest commit in the updates repository for which this commit provides an update." />
+              }
+              aria-label={formatMessage(ariaLabels.ostreeParent)}
+            >
+              <Button variant="plain" aria-label={formatMessage(ariaLabels.ostreeParent)}>
+                <OutlinedQuestionCircleIcon className="cc-c-text__align-icon" id="popover-icon" />
+              </Button>
+            </Popover>
+          }
+          fieldId="ostree-parent-input"
+          hasNoPaddingTop
+        >
+          <TextInput
+            className="pf-c-form-control"
+            value={ostreeSettings.parent !== undefined ? ostreeSettings.parent : ""}
+            type="text"
+            id="ostree-parent-input"
+            onChange={setOstreeParent}
+          />
+        </FormGroup>
+        <FormGroup
+          label={<FormattedMessage defaultMessage="Ref" />}
+          labelIcon={
+            <Popover
+              id="ostree-ref-popover"
+              bodyContent={
+                <FormattedMessage defaultMessage="Provide the name of the branch for the content. If the ref does not already exist it will be created." />
+              }
+              aria-label={formatMessage(ariaLabels.ostreeRef)}
+            >
+              <Button variant="plain" aria-label={formatMessage(ariaLabels.ostreeRef)}>
+                <OutlinedQuestionCircleIcon className="cc-c-text__align-icon" id="popover-icon" />
+              </Button>
+            </Popover>
+          }
+          fieldId="ostree-ref-input"
+          helperText={formatMessage(messages.ostreeRefHelperText)}
+          helperTextInvalid={formatMessage(messages.ostreeRefHelperText)}
+          validated={ostreeRefValidated}
+          hasNoPaddingTop
+        >
+          <TextInput
+            className="pf-c-form-control"
+            value={ostreeSettings.ref !== undefined ? ostreeSettings.ref : ""}
+            type="text"
+            id="ostree-ref-input"
+            aria-describedby="ostree-ref-input-helper-default ostree-ref-input-helper"
+            onChange={this.handleOSTreeRef}
+            validated={ostreeRefValidated}
+          />
+          {ostreeRefValidated === "default" && imageType === "rhel-edge-commit" && (
+            <p className="pf-c-form__helper-text" id="ostree-ref-input-helper-default" aria-live="polite">
+              <FormattedMessage
+                defaultMessage="rhel/8/{arch}/edge is the default, where {arch} is determined by the host machine"
+                values={{
+                  arch: <em>$ARCH</em>,
+                }}
+              />
+            </p>
+          )}
+        </FormGroup>
+      </>
+    );
+
+    const ostreeContainerFields = (
+      <>
+        <FormGroup
+          label={<FormattedMessage defaultMessage="Repository URL" />}
+          labelIcon={
+            <Popover
+              id="ostree-url-popover"
+              bodyContent={
+                <FormattedMessage defaultMessage="Provide the URL of the upstream repository. This repository is where the parent OSTree commit will be pulled from." />
+              }
+              aria-label={formatMessage(ariaLabels.ostreeURL)}
+            >
+              <Button variant="plain" aria-label={formatMessage(ariaLabels.ostreeURL)}>
+                <OutlinedQuestionCircleIcon className="cc-c-text__align-icon" id="popover-icon" />
+              </Button>
+            </Popover>
+          }
+          fieldId="ostree-url-input"
+          hasNoPaddingTop
+        >
+          <TextInput
+            className="pf-c-form-control"
+            value={ostreeSettings.url !== undefined ? ostreeSettings.url : ""}
+            type="text"
+            id="ostree-url-input"
+            onChange={setOstreeURL}
+          />
+        </FormGroup>
+        <FormGroup
+          label={<FormattedMessage defaultMessage="Parent commit" />}
+          labelIcon={
+            <Popover
+              id="ostree-parent-popover"
+              bodyContent={
+                <FormattedMessage
+                  defaultMessage="
+                    Provide the ID of the latest commit in the updates repository for which this commit provides an update. 
+                    If no commit is specified it will be inferred from the parent repository."
+                />
               }
               aria-label={formatMessage(ariaLabels.ostreeParent)}
             >
@@ -509,7 +615,8 @@ class ImageStep extends React.PureComponent {
           {imageType === "vhd" && azureProviderCheckbox}
           {/* {imageType === "vmdk" && vmwareProviderCheckbox} */}
           {requiresImageSize(imageType) && imageSizeInput}
-          {(imageType === "fedora-iot-commit" || imageType === "rhel-edge-commit") && ostreeFields}
+          {(imageType === "fedora-iot-commit" || imageType === "rhel-edge-commit") && ostreeCommitFields}
+          {imageType === "rhel-edge-container" && ostreeContainerFields}
         </Form>
       </>
     );
@@ -533,6 +640,7 @@ ImageStep.propTypes = {
   setImageType: PropTypes.func,
   setOstreeParent: PropTypes.func,
   setOstreeRef: PropTypes.func,
+  setOstreeURL: PropTypes.func,
   uploadService: PropTypes.string,
 };
 
@@ -552,6 +660,7 @@ ImageStep.defaultProps = {
   setImageType() {},
   setOstreeParent() {},
   setOstreeRef() {},
+  setOstreeURL() {},
   uploadService: "",
 };
 

--- a/core/sagas/composes.js
+++ b/core/sagas/composes.js
@@ -128,6 +128,7 @@ function* fetchComposeTypes() {
       qcow2: "QEMU Image (.qcow2)",
       "rhel-edge-commit": "RHEL for Edge Commit (.tar)",
       "rhel-edge-container": "RHEL for Edge Container (.tar)",
+      "rhel-edge-installer": "RHEL for Edge Installer (.iso)",
       vhd: "Microsoft Azure (.vhd)",
       vmdk: "VMWare VSphere (.vmdk)",
     };

--- a/core/sagas/composes.js
+++ b/core/sagas/composes.js
@@ -127,6 +127,7 @@ function* fetchComposeTypes() {
       "partitioned-disk": "Disk Image (.img)",
       qcow2: "QEMU Image (.qcow2)",
       "rhel-edge-commit": "RHEL for Edge Commit (.tar)",
+      "rhel-edge-container": "RHEL for Edge Container (.tar)",
       vhd: "Microsoft Azure (.vhd)",
       vmdk: "VMWare VSphere (.vmdk)",
     };


### PR DESCRIPTION
A user can now select the `RHEL for Edge Container (.tar)` image type. This image type supports the optional ostree fields for a parent commit, a ref for the name of the branch, and a url for the parent repository.

The user can also select the `RHEL for Edge Installer (.iso)` image type. This image type supports the required ostree fields of a ref for the name of the branch and a url for the parent repository.

The help text for the new URL field is `Provide the URL of the upstream repository. This is where the OSTree commit will be pulled from.` Does this explain what the URL represents?

There are currently no tests for this PR because these image types are not yet supported by osbuild-composer. They will not display for selection until they are supported.