### PR TITLE
core: add descriptive label for tar image type

### DIFF
--- a/core/sagas/composes.js
+++ b/core/sagas/composes.js
@@ -123,6 +123,7 @@ function* fetchComposeTypes() {
       google: "Google Cloud Platform (.vhd)",
       "hyper-v": "Hyper-V (.vhd)",
       "live-iso": "Installer, suitable for USB and DVD (.iso)",
+      tar: "Disk Archive (.tar)",
       openstack: "OpenStack (.qcow2)",
       "partitioned-disk": "Disk Image (.img)",
       qcow2: "QEMU Image (.qcow2)",


### PR DESCRIPTION
If the tar image type is available it will now have the descriptive label of Disk Archive (.tar) in the list of image types.