### PR TITLE
package.json: Lock @patternfly/react-styles version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@patternfly/patternfly": "4.80.3",
-    "@patternfly/react-core": "^4.90.2",
+    "@patternfly/react-core": "4.97.2",
     "@patternfly/react-icons": "4.8.4",
     "@patternfly/react-table": "4.20.15",
     "bootstrap": "3.4.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@patternfly/patternfly": "4.80.3",
     "@patternfly/react-core": "4.97.2",
     "@patternfly/react-icons": "4.8.4",
+    "@patternfly/react-styles": "4.8.2",
     "@patternfly/react-table": "4.20.15",
     "bootstrap": "3.4.1",
     "core-js": "3.8.3",


### PR DESCRIPTION
It's part of patternfly-react, so we should update it in a controlled
fashion. Letting it auto-update freely often breaks the build.

Similar to https://github.com/cockpit-project/cockpit/commit/bbde4c01947