### PR TITLE
[rhel8] package.json: Lock @patternfly/react-styles version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@patternfly/patternfly": "4.70.2",
     "@patternfly/react-core": "4.84.4",
     "@patternfly/react-icons": "4.7.22",
+    "@patternfly/react-styles": "4.7.22",
     "@patternfly/react-table": "4.19.45",
     "bootstrap": "3.4.1",
     "core-js": "3.8.3",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@patternfly/patternfly": "4.70.2",
-    "@patternfly/react-core": "4.90.2",
+    "@patternfly/react-core": "4.84.4",
     "@patternfly/react-icons": "4.7.22",
     "@patternfly/react-table": "4.19.45",
     "bootstrap": "3.4.1",


### PR DESCRIPTION
It's part of patternfly-react, so we should update it in a controlled
fashion. Letting it auto-update freely often breaks the build.

package.json's versions of PatternFly in this branch don't build any
more with the current react-styles version:

    ERROR in ./node_modules/@patternfly/react-core/dist/esm/components/Drawer/DrawerPanelContent.js
    Module not found: Error: Can't resolve '@patternfly/react-styles/css/components/Drawer/DrawerIframe'
      in 'cockpit-composer/node_modules/@patternfly/react-core/dist/esm/components/Drawer'

Pin down react-styles to the version that it had for release 28.