### PR TITLE
wizard: translate image type labels

### DIFF
--- a/components/Wizard/ImageStep.js
+++ b/components/Wizard/ImageStep.js
@@ -501,7 +501,12 @@ class ImageStep extends React.PureComponent {
             <FormSelect value={imageType} id="image-type" onChange={this.handleImageTypeSelect} isRequired>
               <FormSelectOption isDisabled key="default" value="" label={formatMessage(messages.selectOne)} />
               {imageTypes.map((type) => (
-                <FormSelectOption isDisabled={!type.enabled} key={type.name} value={type.name} label={type.label} />
+                <FormSelectOption
+                  isDisabled={!type.enabled}
+                  key={type.name}
+                  value={type.name}
+                  label={formatMessage({ id: type.name, defaultMessage: type.label })}
+                />
               ))}
             </FormSelect>
           </FormGroup>


### PR DESCRIPTION
Most of the image type labels are proper nouns and haven't needed to be translated. But, with the addition of a descriptive label for tar, these labels should now be translated.