### PR TITLE
test: allow avc denial messages on cancel image

### DIFF
--- a/test/verify/check-image
+++ b/test/verify/check-image
@@ -668,6 +668,7 @@ class TestImage(composerlib.ComposerCase):
         b.wait_attr("#{}-actions".format(uuid), "aria-expanded", "true")
         b.click("li[aria-labelledby={}] a:contains('Remove')".format(selector))
         b.wait_not_present("#{}".format(selector))
+        self.allow_journal_messages(".*avc:  denied.*")
 
         # collect code coverage result
         self.check_coverage()


### PR DESCRIPTION
The fedora 32 test is consistently failing due to an avc denial error as seen on this PR https://github.com/osbuild/cockpit-composer/pull/1240. 