### PR TITLE
test: double image build timeout

### DIFF
--- a/test/verify/check-image
+++ b/test/verify/check-image
@@ -504,7 +504,7 @@ class TestImage(composerlib.ComposerCase):
         self.assertEqual(image_type.lower(), "openstack")
 
         # image building needs more time
-        with b.wait_timeout(1800):
+        with b.wait_timeout(3600):
             b.wait_text("li[aria-labelledby={}] [data-status=true]".format(selector),
                         "Image build complete")
         # image size should be 4GB
@@ -589,7 +589,7 @@ class TestImage(composerlib.ComposerCase):
         self.assertEqual(image_type, image_type_ostree)
 
         # image building needs more time
-        with b.wait_timeout(1800):
+        with b.wait_timeout(3600):
             b.wait_text("li[aria-labelledby={}] [data-status=true]".format(selector),
                         "Image build complete")
         # log should contains rpm, hostname, users stages and tar assembler


### PR DESCRIPTION
Set it to 60m rather than 30m.

Either should be plenty, but in order to eliminate slow builds as a source of false negatives, let's up the limit.