### PR TITLE
cockpituous: Add Fedora 34, drop Fedora 32

### DIFF
--- a/utils/cockpituous-release
+++ b/utils/cockpituous-release
@@ -17,12 +17,12 @@ job release-srpm -V
 
 # Do fedora builds for the tag, using tarball
 job release-koji rawhide
-job release-koji f32
 job release-koji f33 
+job release-koji f34
 
 job release-github
 job release-copr @osbuild/cockpit-composer
 
 # Create a Bodhi update for stable Fedora releases
-job release-bodhi F32
 job release-bodhi F33
+job release-bodhi F34


### PR DESCRIPTION
bodhi activation for Fedora 34 is today [1]. Drop Fedora 32 instead,
which is soon EOL.

[1] https://fedorapeople.org/groups/schedule/f-34/f-34-key-tasks.html

----

This is what I did to cockpit{,-podman,ostree}. Of course feel free to adjust if you want to keep F32 for a while. This is mostly a reminder that this needs doing.