### PR TITLE
test: Bump cockpit test API to 239

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ machine: bots
 # checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
 # this needs a recent adjustment for firefox 77 and working with network-enabled tests
 test/common:
-	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 233
+	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 239
 	git checkout --force FETCH_HEAD -- test/common
 	git reset test/common
 


### PR DESCRIPTION
I will work on bringing back the `@nondestructive` tests, that will require a new option in `run-tests`. Let's first make sure that composer tests work with the most recent release.

 - [ ] https://github.com/cockpit-project/bots/pull/1787