### PR TITLE
Run CDP tests in bigger machines, re-enable all tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ vm: $(VM_IMAGE)
 
 # run the CDP integration test
 check: $(VM_IMAGE) test/common machine
-	test/common/run-tests --test-dir=test/verify --enable-network
+	test/common/run-tests --nondestructive-memory-mb 2048 --test-dir=test/verify --enable-network
 
 # run test with browser interactively
 debug-check:
@@ -152,9 +152,8 @@ machine: bots
 	rsync -avR --exclude="bots/machine/machine_core/__pycache__/" bots/machine/testvm.py bots/machine/identity bots/machine/cloud-init.iso bots/machine/machine_core bots/lib test
 
 # checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
-# this needs a recent adjustment for firefox 77 and working with network-enabled tests
 test/common:
-	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 233
+	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 242
 	git checkout --force FETCH_HEAD -- test/common
 	git reset test/common
 

--- a/test/verify/check-image
+++ b/test/verify/check-image
@@ -505,13 +505,6 @@ class TestImage(composerlib.ComposerCase):
         # collect code coverage result
         self.check_coverage()
 
-
-# these tests don't get along with just the standard 1.1GiB @nondestructive VMs
-@testlib.timeout(2400)
-@testlib.no_retry_when_changed
-class TestLargeImage(composerlib.ComposerCase):
-    provision = {"machine1": {"cpus": 2, "memory_mb": 2048}}
-
     def testOSTreeCommit(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
As described in commit a7577b988c1fd, some tests need more memory than the standard 1.1GiB RAM nondestructive VMs. Use the new run-tests options introduced in https://github.com/cockpit-project/cockpit/pull/15509 (released in Cockpit 240) to run all our tests in a bigger machine.

Revert "test: Run OSTree and Openstack tests in VM with more RAM". This is not necessary any more with bigger nondestructive machines, and will re-enable these tests for downstream gating.

This currently checks out my bots fork, just to prove that this works. But of course we can't land it like that, so blocked for now.

 - [x] Land https://github.com/cockpit-project/cockpit/pull/15509
 - [x] Fix machine_core messages: https://github.com/cockpit-project/bots/pull/1787
 - [x] Adjust test/common checkout to get that bots commit