### PR TITLE
CreateImageUpload: require slash in url

### DIFF
--- a/components/Wizard/CreateImageUpload.js
+++ b/components/Wizard/CreateImageUpload.js
@@ -78,6 +78,7 @@ class CreateImageUploadModal extends React.Component {
     this.isValidImageSize = this.isValidImageSize.bind(this);
     this.isValidOstree = this.isValidOstree.bind(this);
     this.isValidOstreeRef = this.isValidOstreeRef.bind(this);
+    this.isValidOstreeUrl = this.isValidOstreeUrl.bind(this);
     this.requiresImageSize = this.requiresImageSize.bind(this);
     this.missingRequiredFields = this.missingRequiredFields.bind(this);
     this.setNotifications = this.setNotifications.bind(this);
@@ -352,7 +353,9 @@ class CreateImageUploadModal extends React.Component {
   isValidOstree() {
     if (this.state.ostreeSettings.parent && this.state.ostreeSettings.url) return false;
     if (this.state.imageType === "rhel-edge-installer" && !this.state.ostreeSettings.url) return false;
-    return this.isValidOstreeRef(this.state.ostreeSettings.ref);
+    if (!this.isValidOstreeRef(this.state.ostreeSettings.ref)) return false;
+    if (!this.isValidOstreeUrl(this.state.ostreeSettings.url)) return false;
+    return true;
   }
 
   isValidOstreeRef(ref) {
@@ -360,6 +363,13 @@ class CreateImageUploadModal extends React.Component {
     // This regex is based on https://github.com/ostreedev/ostree/blob/73742252e286e8b53677555dc1b0d52d55fb7012/src/libostree/ostree-core.c#L151
     const refValidationRegex = /^(?:[\w\d][-._\w\d]*\/)*[\w\d][-._\w\d]*$/;
     return ref === "" || refValidationRegex.test(ref);
+  }
+
+  isValidOstreeUrl(url) {
+    if (url) {
+      const lastChar = url.substr(-1);
+      return lastChar === "/";
+    }
   }
 
   render() {
@@ -377,6 +387,7 @@ class CreateImageUploadModal extends React.Component {
           imageType={this.state.imageType}
           imageTypes={this.props.imageTypes}
           isValidOstreeRef={this.isValidOstreeRef}
+          isValidOstreeUrl={this.isValidOstreeUrl}
           isPendingChange={this.isPendingChange}
           minImageSize={this.state.minImageSize}
           maxImageSize={this.state.maxImageSize}

--- a/components/Wizard/ImageStep.js
+++ b/components/Wizard/ImageStep.js
@@ -195,16 +195,16 @@ class ImageStep extends React.PureComponent {
   handleOSTreeURL(url) {
     if (!url) {
       this.setState({
+        ostreeURLValidated: "default",
         ostreeCommitValidated: "default",
       });
-    }
-    if (this.props.ostreeSettings.parent && url) {
+    } else if (!this.props.isValidOstreeUrl(url) || (this.props.ostreeSettings.parent && url)) {
       this.setState({
         ostreeURLValidated: "error",
       });
     } else {
       this.setState({
-        ostreeURLValidated: "default",
+        ostreeURLValidated: "success",
       });
     }
     this.props.setOstreeURL(url);
@@ -219,6 +219,7 @@ class ImageStep extends React.PureComponent {
       imageType,
       imageTypes,
       isPendingChange,
+      isValidOstreeUrl,
       minImageSize,
       maxImageSize,
       ostreeSettings,
@@ -480,7 +481,7 @@ class ImageStep extends React.PureComponent {
             onChange={this.handleOSTreeURL}
             validated={ostreeURLValidated}
           />
-          {ostreeURLValidated === "error" && (
+          {ostreeURLValidated === "error" && isValidOstreeUrl(ostreeSettings.url) && (
             <p className="pf-c-form__helper-text pf-m-error" id="ostree-url-input-helper-error" aria-live="polite">
               <FormattedMessage defaultMessage="Either the parent commit or repository url can be specified. Not both." />
             </p>
@@ -585,8 +586,8 @@ class ImageStep extends React.PureComponent {
             </Popover>
           }
           fieldId="ostree-url-input"
-          helperTextInvalid={formatMessage(messages.requiredField)}
-          validated={ostreeSettings.url !== "" ? "default" : "error"}
+          helperTextInvalid={!ostreeSettings.url ? formatMessage(messages.requiredField) : ""}
+          validated={ostreeSettings.url !== "" ? ostreeURLValidated : "error"}
           isRequired
           hasNoPaddingTop
         >
@@ -596,7 +597,7 @@ class ImageStep extends React.PureComponent {
             type="text"
             id="ostree-url-input"
             onChange={this.handleOSTreeURL}
-            validated={ostreeSettings.url !== "" ? "default" : "error"}
+            validated={ostreeSettings.url !== "" ? ostreeURLValidated : "error"}
           />
         </FormGroup>
         <FormGroup
@@ -728,6 +729,7 @@ ImageStep.propTypes = {
   imageTypes: PropTypes.arrayOf(PropTypes.object),
   imageSize: PropTypes.number,
   isValidOstreeRef: PropTypes.func,
+  isValidOstreeUrl: PropTypes.func,
   isPendingChange: PropTypes.func,
   minImageSize: PropTypes.number,
   maxImageSize: PropTypes.number,
@@ -748,6 +750,7 @@ ImageStep.defaultProps = {
   imageTypes: [],
   imageSize: undefined,
   isValidOstreeRef() {},
+  isValidOstreeUrl() {},
   isPendingChange() {},
   minImageSize: 0,
   maxImageSize: 2000,


### PR DESCRIPTION
The edge image type's url requires a slash at the end of the url. If no slash is present show an error icon on the field and disable image creation.

An error message should be added for this validation to explain the failure but I am opening this PR without it in case this needs to be backported to RHEL 8.4