### PR TITLE
test: update check-source

### DIFF
--- a/test/verify/check-source
+++ b/test/verify/check-source
@@ -15,10 +15,9 @@ class TestSource(composerlib.ComposerCase):
         b = self.browser
         m = self.machine
 
-        # new repo info
-        repo_url = "https://download.copr.fedorainfracloud.org/results" \
-            "/xiaofwan/sway-copr/fedora-31-x86_64"
-        repo_name = "sway-copr"
+        # new source info
+        source_url = "https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-30&arch=x86_64"
+        source_name = "fedora-30-mirrorlist"
 
         self.login_and_go("/composer", superuser=True)
         b.wait_visible("#main")
@@ -39,17 +38,17 @@ class TestSource(composerlib.ComposerCase):
         # add new source
         b.click("input[value='Add source']")
 
-        # can't add srouce if type is empty
-        b.set_input_text("#textInput1-modal-source", repo_name)
-        b.set_input_text("#textInput2-modal-source", repo_url)
+        # can't add source if type is empty
+        b.set_input_text("#textInput1-modal-source", source_name)
+        b.set_input_text("#textInput2-modal-source", source_url)
         b.wait_attr("button:contains('Add source')", "disabled", "")
         b.click("button:contains('Cancel')")
         # new source
         b.click("input[value='Add source']")
-        b.set_input_text("#textInput1-modal-source", repo_name)
-        b.set_input_text("#textInput2-modal-source", repo_url)
-        b.set_val("#textInput3-modal-source", "yum-baseurl")
-        b.wait_val("#textInput3-modal-source", "yum-baseurl")
+        b.set_input_text("#textInput1-modal-source", source_name)
+        b.set_input_text("#textInput2-modal-source", source_url)
+        b.set_val("#textInput3-modal-source", "yum-mirrorlist")
+        b.wait_val("#textInput3-modal-source", "yum-mirrorlist")
         # groups action done
         b.click("button:contains('Add source')")
 
@@ -64,28 +63,14 @@ class TestSource(composerlib.ComposerCase):
             b.wait_attr(drop_down_sel, "aria-expanded", "false")
             b.wait_visible("#cmpsr-modal-manage-sources")
 
-        # endit new source to enable check SSL certificate and GPG key
-        b.click("button[aria-label='Edit source {}']".format(repo_name))
+        # edit existing source to enable check SSL certificate and GPG key
+        b.click("button[aria-label='Edit source {}']".format(source_name))
         # SSL certificate
         b.click("#checkboxInput4-modal-source")
         # GPG key
         b.click("#checkboxInput5-modal-source")
         b.click("button:contains('Update source')")
 
-        # package from new added repo is here already
-        b.click("button:contains('Close')")
-        b.click("li[data-blueprint=openssh-server] a:contains('Edit packages')")
-        # wait for all available compontents visible
-        with b.wait_timeout(300):
-            b.wait_visible("ul[data-list=inputs]")
-        # search for kanshi which exists in added repo only
-        b.set_input_text("#cmpsr-blueprint-input-filter", "kanshi")
-        b.key_press("\r")
-        with b.wait_timeout(120):
-            b.wait_text("#kanshi-input", "kanshi")
-        # new added reop works, go back
-        # click back to blueprint link
-        b.click("a:contains('Back to blueprints')")
         # go to manage source
         b.click(drop_down_sel)
         b.wait_attr(drop_down_sel, "aria-expanded", "true")
@@ -95,16 +80,16 @@ class TestSource(composerlib.ComposerCase):
 
         # duplicated source can't be added
         b.click("input[value='Add source']")
-        b.set_input_text("#textInput2-modal-source", repo_url)
+        b.set_input_text("#textInput2-modal-source", source_url)
         b.wait_text("#textInput2-modal-source-help", "This source path already exists.")
         b.click("button:contains('Cancel')")
 
         # delete added source
-        delete_drop_down_sel = "button[aria-label='Source actions {}']".format(repo_name)
+        delete_drop_down_sel = "button[aria-label='Source actions {}']".format(source_name)
         b.click(delete_drop_down_sel)
         b.wait_attr(delete_drop_down_sel, "aria-expanded", "true")
         b.click("a:contains('Remove source')")
-        b.wait_not_present("div[data-source={}]".format(repo_name))
+        b.wait_not_present("div[data-source={}]".format(source_name))
 
         # close manage source dialog
         b.click("#cmpsr-modal-manage-sources .close")


### PR DESCRIPTION
The repo url in check-source's testBasic was broken. This has now been replaced by a fedora 30 mirrorlist which should maintain more reliability. Additionally the packages check is removed from this test. Packages are checked in the check-package test.