### PR TITLE
webpack.config.js: silent sass deprecation warnings

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -152,6 +152,7 @@ module.exports = {
                   path.resolve(nodedir, "bootstrap-sass", "assets", "stylesheets"),
                 ],
                 outputStyle: "compressed",
+                quietDeps: true,
               },
             },
           },


### PR DESCRIPTION
We're getting a lot of warnings like

  DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

from PatternFly 3.

We can disable these warnings for our dependencies with the
`quietDeps` option to Dart Sass, as we do in the cockpit repo.