### PR TITLE
Makefile: update weblate branch to 'main'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ WEBPACK_TEST=public/dist/index.html
 
 WEBLATE_REPO=tmp/weblate-repo
 WEBLATE_REPO_URL=https://github.com/osbuild/cockpit-composer-weblate.git
-WEBLATE_REPO_BRANCH=master
+WEBLATE_REPO_BRANCH=main
 
 all: $(WEBPACK_TEST)
 


### PR DESCRIPTION
The cockpit-composer-weblate repo is now using 'main', as well.