### PR TITLE
Test against fedora 33 and 34

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 VERSION=$(shell $(CURDIR)/rpmversion.sh | cut -d - -f 1)
 RELEASE=$(shell $(CURDIR)/rpmversion.sh | cut -d - -f 2)
 PACKAGE_NAME := $(shell awk '/"name":/ {gsub(/[",]/, "", $$2); print $$2}' package.json)
-TEST_OS ?= fedora-32
+TEST_OS ?= fedora-33
 export TEST_OS
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)
 ifneq (,$(wildcard ~/.config/codecov-token))

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ By default the cockpit-composer will be installed into `$TEST_OS`in [Makefile](M
 
 To test cockpit-composer in different OS, set the `$TEST_OS` environment variable, for example:
 
-    $ TEST_OS=fedora-32 make check
+    $ TEST_OS=fedora-33 make check
 
 ### Running eslint
 

--- a/test/README.md
+++ b/test/README.md
@@ -63,8 +63,8 @@ interactively follow what a test is doing, set environment variable `$TEST_SHOW_
 You can set these environment variables to configure the test suite:
 
     TEST_OS    The OS to run the tests in.  Currently supported values:
-                  "fedora-32, fedora-33, rhel-8-4"
-               "fedora-32" is the default
+                  "fedora-33, fedora-34, rhel-8-4"
+               "fedora-33" is the default
 
     TEST_DATA  Where to find and store test machine images.  The
                default is the same directory that this README file is in.

--- a/test/verify/check-image
+++ b/test/verify/check-image
@@ -510,7 +510,7 @@ class TestImage(composerlib.ComposerCase):
         m = self.machine
 
         distro = os.environ.get("TEST_OS")
-        if (distro == "fedora-32" or distro == "fedora-33"):
+        if (distro == "fedora-33" or distro == "fedora-34"):
             image_type_ostree = "fedora-iot-commit"
         elif (distro == "rhel-8-3" or distro == "rhel-8-4"):
             image_type_ostree = "rhel-edge-commit"


### PR DESCRIPTION
Update makefile, tests, and README to test against f34. The default testing environment is now f33.