### PR TITLE
core: don't display unsuported image types

### DIFF
--- a/core/sagas/composes.js
+++ b/core/sagas/composes.js
@@ -133,8 +133,12 @@ function* fetchComposeTypes() {
       vhd: "Microsoft Azure (.vhd)",
       vmdk: "VMWare VSphere (.vmdk)",
     };
-    const imageTypesLabelled = imageTypes.map((type) => {
-      return { ...type, label: imageTypeLabels[type.name] || type.name };
+    const imageTypesLabelled = [];
+    imageTypes.forEach((type) => {
+      if (type.name in imageTypeLabels) {
+        const typeLabelled = { ...type, label: imageTypeLabels[type.name] };
+        imageTypesLabelled.push(typeLabelled);
+      }
     });
     yield put(fetchingComposeTypesSucceeded(imageTypesLabelled));
   } catch (error) {


### PR DESCRIPTION
If an image type was supported by osbuild-composer but not cockpit-composer it would still be displayed. Now, an image type must be listed in the list of imageTypeLabels for it to be displayed in the list of available image types.