### PR TITLE
test: simplify testExport

### DIFF
--- a/test/verify/check-blueprint
+++ b/test/verify/check-blueprint
@@ -5,8 +5,6 @@
 # 2. blueprint filter
 # 3. blueprint sort
 
-import re
-
 import composerlib
 import testlib
 
@@ -139,7 +137,6 @@ class TestBlueprint(composerlib.ComposerCase):
 
     def testExport(self):
         b = self.browser
-        m = self.machine
 
         self.login_and_go("/composer", superuser=True)
         b.wait_visible("#main")
@@ -152,26 +149,9 @@ class TestBlueprint(composerlib.ComposerCase):
         b.wait_visible("#cmpsr-modal-export")
         with b.wait_timeout(300):
             b.wait_in_text("#textInput2-modal-markup", "openssh-server")
-        packages_list = b.text("#textInput2-modal-markup")
         b.click("#cmpsr-modal-export button[data-btn=copy-export]")
         b.click("#cmpsr-modal-export button[data-btn=close-export]")
         b.wait_not_present("#cmpsr-modal-export")
-
-        list_from_backend = m.execute("""
-            composer-cli blueprints depsolve openssh-server | tail -n +2
-            """).split()
-        # remove tailing ".x86_64" or ".noarch"(6 chars) or ".aarch64"(7 chars)
-        # and "*:" in libpcap-14:1.9.1-2.fc31.x86_64
-        regex = re.compile("-[0-9]*:")
-
-        def remove(x):
-            if x.endswith("aarch64"):
-                return regex.sub("-", x[:-8])
-            else:
-                return regex.sub("-", x[:-7])
-        format_list = map(remove, list_from_backend)
-
-        self.assertEqual(packages_list, "\n".join(format_list))
 
         # collect code coverage result
         self.check_coverage()

--- a/test/verify/check-custom
+++ b/test/verify/check-custom
@@ -5,58 +5,12 @@
 # 2. blueprint description edit/update
 # 3. hostname setting
 # 4. user setting
-
-import re
-
 import composerlib
 import testlib
 
 
 @testlib.nondestructive
 class TestCustom(composerlib.ComposerCase):
-
-    def testExport(self):
-        b = self.browser
-        m = self.machine
-
-        self.login_and_go("/composer", superuser=True)
-        b.wait_visible("#main")
-
-        # go to blueprint openssh-server
-        b.click("#openssh-server-name")
-
-        # export package list
-        actions_drop_down_sel = ".cmpsr-header__actions #dropdownKebab"
-        with b.wait_timeout(300):
-            b.click(actions_drop_down_sel)
-        b.wait_attr(actions_drop_down_sel, "aria-expanded", "true")
-        b.click("a:contains('Export')")
-        b.wait_visible("#cmpsr-modal-export")
-        with b.wait_timeout(300):
-            b.wait_in_text("#textInput2-modal-markup", "openssh-server")
-        packages_list = b.text("#textInput2-modal-markup")
-        b.click("#cmpsr-modal-export button[data-btn=copy-export]")
-        b.click("#cmpsr-modal-export button[data-btn=close-export]")
-        b.wait_not_present("#cmpsr-modal-export")
-
-        list_from_backend = m.execute("""
-            composer-cli blueprints depsolve openssh-server | tail -n +2
-            """).split()
-        # remove tailing ".x86_64" or ".noarch"(6 chars) or ".aarch64"(7 chars)
-        # and "*:" in libpcap-14:1.9.1-2.fc31.x86_64
-        regex = re.compile("-[0-9]*:")
-
-        def remove(x):
-            if x.endswith("aarch64"):
-                return regex.sub("-", x[:-8])
-            else:
-                return regex.sub("-", x[:-7])
-        format_list = map(remove, list_from_backend)
-
-        self.assertEqual(packages_list, "\n".join(format_list))
-
-        # collect code coverage result
-        self.check_coverage()
 
     def testDescription(self):
         b = self.browser


### PR DESCRIPTION
The export modal test does not need to verify the contents of cockpit-composer and composer-cli. It is unnecessary to test against composer-cli. Also, the export test in TestCustom is removed since it is a duplicate test.