### PR TITLE
alerts: include error message

### DIFF
--- a/components/Notifications/Notifications.js
+++ b/components/Notifications/Notifications.js
@@ -1,10 +1,16 @@
 import React from "react";
-import { FormattedMessage, injectIntl } from "react-intl";
+import { defineMessages, FormattedMessage, injectIntl, intlShape } from "react-intl";
 import { connect } from "react-redux";
 import PropTypes from "prop-types";
 import { Alert, AlertActionCloseButton, AlertGroup } from "@patternfly/react-core";
 import "./Notifications.css";
 import { alertDelete } from "../../core/actions/alerts";
+
+const messages = defineMessages({
+  errorSubscription: {
+    defaultMessage: "This system does not have any valid subscriptions.",
+  },
+});
 
 class Notifications extends React.PureComponent {
   constructor() {
@@ -12,6 +18,8 @@ class Notifications extends React.PureComponent {
   }
 
   render() {
+    const { formatMessage } = this.props.intl;
+
     return (
       <AlertGroup isToast>
         {this.props.alerts.map((alert) => {
@@ -81,15 +89,18 @@ class Notifications extends React.PureComponent {
                   variant="danger"
                   title={
                     <FormattedMessage
-                      defaultMessage="{blueprint} Image creation {queue}."
+                      defaultMessage="{blueprint} Image creation failed."
                       values={{
                         blueprint: <strong>{alert.blueprintName}:</strong>,
-                        queue: <a href={`#blueprint/${alert.blueprintName}/images`}>failed</a>,
                       }}
                     />
                   }
                   actionClose={<AlertActionCloseButton onClose={() => this.props.alertDelete(alert.id)} />}
-                />
+                >
+                  {alert.error ===
+                    "This system does not have any valid subscriptions. Subscribe it before specifying rhsm: true in sources." &&
+                    formatMessage(messages.errorSubscription)}
+                </Alert>
               );
             }
             case "blueprintCommitStarted": {
@@ -158,6 +169,7 @@ class Notifications extends React.PureComponent {
 Notifications.propTypes = {
   alerts: PropTypes.arrayOf(PropTypes.object),
   alertDelete: PropTypes.func,
+  intl: intlShape.isRequired,
 };
 
 Notifications.defaultProps = {

--- a/components/Wizard/CreateImageUpload.js
+++ b/components/Wizard/CreateImageUpload.js
@@ -188,7 +188,7 @@ class CreateImageUploadModal extends React.Component {
           .catch((e) => console.log(`Error in reload blueprint details: ${e}`));
       })
       .catch((e) => {
-        this.props.alertAdd(uuid(), "blueprintCommitFailed", this.props.blueprint.name);
+        this.props.alertAdd(uuid(), "blueprintCommitFailed", this.props.blueprint.name, e);
         console.log(`Error in blueprint commit: ${e}`);
       });
   }

--- a/core/actions/alerts.js
+++ b/core/actions/alerts.js
@@ -1,10 +1,11 @@
 export const ALERT_ADD = "ALERT_ADD";
-export const alertAdd = (id, type, blueprintName) => ({
+export const alertAdd = (id, type, blueprintName, error) => ({
   type: ALERT_ADD,
   payload: {
     id,
     type,
     blueprintName,
+    error,
   },
 });
 

--- a/core/reducers/alerts.js
+++ b/core/reducers/alerts.js
@@ -9,6 +9,7 @@ const alerts = (state = [], action) => {
           id: action.payload.id,
           type: action.payload.type,
           blueprintName: action.payload.blueprintName,
+          error: action.payload.error,
         },
       ];
     case ALERT_DELETE:

--- a/core/sagas/composes.js
+++ b/core/sagas/composes.js
@@ -41,7 +41,8 @@ function* startCompose(action) {
     }
   } catch (error) {
     console.log("startComposeError", error);
-    yield put(alertAdd(uuid(), "composeFailed", blueprintName));
+    const errorMessage = error.body.errors[0].msg;
+    yield put(alertAdd(uuid(), "composeFailed", blueprintName, errorMessage));
     yield put(composesFailure(error));
   }
 }
@@ -67,7 +68,7 @@ function* pollComposeStatus(compose) {
     }
   } catch (error) {
     console.log("pollComposeStatusError", error);
-    yield put(alertAdd(uuid(), "composeFailed", compose.blueprint));
+    yield put(alertAdd(uuid(), "composeFailed", compose.blueprint, error));
     yield put(composesFailure(error));
   }
 }

--- a/pages/blueprintEdit/index.js
+++ b/pages/blueprintEdit/index.js
@@ -177,7 +177,7 @@ class EditBlueprintPage extends React.Component {
           .catch((e) => console.log(`Error in reload blueprint details: ${e}`));
       })
       .catch((e) => {
-        this.props.alertAdd(uuid(), "blueprintCommitFailed", this.props.blueprint.name);
+        this.props.alertAdd(uuid(), "blueprintCommitFailed", this.props.blueprint.name, e);
         console.log(`Error in blueprint commit: ${e}`);
       });
   }


### PR DESCRIPTION
Alerts can now pass along an error. If a compose fails the error will be included in the alert. Currently, only a failed depsolve due to no subscription will display a message. All failures will display the alert but only errors mapped to a translated string will display an error message.