### PR TITLE
package.json: remove core-js-compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "@patternfly/react-table": "4.30.3",
     "bootstrap": "3.4.1",
     "core-js": "3.15.1",
-    "core-js-compat": "3.15.1",
     "fastclick": "1.0.6",
     "history": "3.3.0",
     "jquery": "3.5.1",


### PR DESCRIPTION
core-js-compat is used for getting a list of required core-js modules. We do not use this feature and have no use for core-js-compat.

https://www.npmjs.com/package/core-js-compat