### PR TITLE
Wizard: support RHEL Installer image type

### DIFF
--- a/components/Wizard/CreateImageUpload.js
+++ b/components/Wizard/CreateImageUpload.js
@@ -329,7 +329,8 @@ class CreateImageUploadModal extends React.Component {
       imageType === "rhel-edge-installer" ||
       imageType === "edge-commit" ||
       imageType === "edge-container" ||
-      imageType === "edge-installer"
+      imageType === "edge-installer" ||
+      imageType === "image-installer"
     ) {
       return false;
     }

--- a/core/sagas/composes.js
+++ b/core/sagas/composes.js
@@ -144,6 +144,7 @@ function* fetchComposeTypes() {
       "edge-container": "RHEL for Edge Container (.tar)",
       "edge-installer": "RHEL for Edge Installer (.iso)",
       "edge-raw-image": "RHEL for Edge Raw Image (.raw.xz)",
+      "image-installer": "RHEL Installer (.iso)",
       vhd: "Microsoft Azure (.vhd)",
       vmdk: "VMWare VSphere (.vmdk)",
     };

--- a/test/verify/check-image
+++ b/test/verify/check-image
@@ -844,6 +844,23 @@ class TestImage(composerlib.ComposerCase):
         # collect code coverage result
         self.check_coverage()
 
+    @unittest.skipIf(os.environ.get("TEST_OS").split('-')[0] != "rhel", "Does not support image-installer image type")
+    def testRHELInstaller(self):
+        b = self.browser
+
+        self.login_and_go("/composer", superuser=True)
+        b.wait_visible("#main")
+
+        b.click("li[data-blueprint=httpd-server] #create-image-button")
+        b.wait_text("#create-image-upload-wizard #blueprint-name", "httpd-server")
+        b.wait_js_cond('ph_select("#image-type option").length > 1')
+        b.set_val("#image-type", "image-installer")
+        # The continue button should be enabled since no fields are required
+        self.assertEqual(b.call_js_func('ph_has_attr', "#continue-button", "disabled", ""), False)
+
+        # collect code coverage result
+        self.check_coverage()
+
 
 if __name__ == '__main__':
     testlib.test_main()


### PR DESCRIPTION
The image-installer image type is now available in cockpit-composer. Users can select it in the Create Image Wizard. It has no required configuration. Testing is added to verify the fields display as expected.

![rhelInstaller](https://user-images.githubusercontent.com/11712857/135446376-83b2fe9c-0c10-4984-924f-971d8ad365b5.png)
