### PR TITLE
Wizard: add Edge Raw Image type

### DIFF
--- a/components/Wizard/CreateImageUpload.js
+++ b/components/Wizard/CreateImageUpload.js
@@ -298,7 +298,7 @@ class CreateImageUploadModal extends React.Component {
     if (this.state.imageType === "") return true;
     if (
       this.requiresImageSize(this.state.imageType) &&
-      (this.state.imageSize === undefined || (!this.isValidImageSize() && this.state.uploadService === ""))
+      (!this.state.imageSize || (!this.isValidImageSize() && !this.state.uploadService))
     ) {
       return true;
     }
@@ -352,7 +352,9 @@ class CreateImageUploadModal extends React.Component {
   isValidOstree() {
     if (this.state.ostreeSettings.parent && this.state.ostreeSettings.url) return false;
     if (
-      (this.state.imageType === "edge-installer" || this.state.imageType === "rhel-edge-installer") &&
+      (this.state.imageType === "edge-installer" ||
+        this.state.imageType === "rhel-edge-installer" ||
+        this.state.imageType === "edge-raw-image") &&
       !this.state.ostreeSettings.url
     ) {
       return false;

--- a/components/Wizard/ImageStep.js
+++ b/components/Wizard/ImageStep.js
@@ -567,7 +567,7 @@ class ImageStep extends React.PureComponent {
       </>
     );
 
-    const ostreeInstallerFields = (
+    const ostreeInstallerRawFields = (
       <>
         <FormGroup
           label={<FormattedMessage defaultMessage="Repository URL" />}
@@ -714,7 +714,8 @@ class ImageStep extends React.PureComponent {
           {(imageType === "fedora-iot-commit" || imageType === "edge-commit" || imageType === "rhel-edge-commit") &&
             ostreeFields}
           {(imageType === "edge-container" || imageType === "rhel-edge-container") && ostreeFields}
-          {(imageType === "edge-installer" || imageType === "rhel-edge-installer") && ostreeInstallerFields}
+          {(imageType === "edge-installer" || imageType === "rhel-edge-installer" || imageType === "edge-raw-image") &&
+            ostreeInstallerRawFields}
         </Form>
       </>
     );

--- a/core/sagas/composes.js
+++ b/core/sagas/composes.js
@@ -143,6 +143,7 @@ function* fetchComposeTypes() {
       "edge-commit": "RHEL for Edge Commit (.tar)",
       "edge-container": "RHEL for Edge Container (.tar)",
       "edge-installer": "RHEL for Edge Installer (.iso)",
+      "edge-raw-image": "RHEL for Edge Raw Image (.raw.xz)",
       vhd: "Microsoft Azure (.vhd)",
       vmdk: "VMWare VSphere (.vmdk)",
     };

--- a/test/verify/check-image
+++ b/test/verify/check-image
@@ -722,6 +722,41 @@ class TestImage(composerlib.ComposerCase):
         # collect code coverage result
         self.check_coverage()
 
+    # Currently only supported on rhel-8-5
+    @unittest.skipIf(os.environ.get("TEST_OS") != "rhel-8-5", "Does not support ostree image image type")
+    def testEdgeRaw(self):
+        b = self.browser
+
+        self.login_and_go("/composer", superuser=True)
+        b.wait_visible("#main")
+
+        # create image wizard
+        b.click("li[data-blueprint=httpd-server] #create-image-button")
+        b.wait_text("#create-image-upload-wizard #blueprint-name", "httpd-server")
+        b.wait_js_cond('ph_select("#image-type option").length > 1')
+        b.set_val("#image-type", "edge-raw-image")
+        # check url help button
+        b.click("button[aria-label='OSTree repo url help']")
+        b.text(".pf-c-popover__body")
+        b.wait_text(".pf-c-popover__body",
+                    "Provide the URL of the upstream repository. This repository is where the parent OSTree commit will be pulled from.")
+        b.click(".pf-c-popover__content button")
+        b.wait_not_present(".pf-c-popover__body")
+        # check ref help button
+        b.click("button[aria-label='OSTree ref help']")
+        b.text(".pf-c-popover__body")
+        b.wait_text(".pf-c-popover__body", "Provide the name of the branch for the content. If the ref does not already exist it will be created.")
+        b.click(".pf-c-popover__content button")
+        b.wait_not_present(".pf-c-popover__body")
+
+        # without a url entered the continue button should be disabled
+        b.wait_attr("#continue-button", "disabled", "")
+
+        self.allow_journal_messages(".*avc:  denied.*",
+                                    ".*audit: .*seresult=denied .*")
+        # collect code coverage result
+        self.check_coverage()
+
     def testOpenStack(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
Add support for the edge-raw-image image type. The Repo URL is required and the user can add an optional branch ref. Testing is added to verify the fields display.

![rawimage](https://user-images.githubusercontent.com/11712857/135496268-af5f5dd4-d542-471d-b9a3-1e938445a9d8.png)

