### PR TITLE
blueprint: add installation_device customization

### DIFF
--- a/core/actions/blueprints.js
+++ b/core/actions/blueprints.js
@@ -95,6 +95,15 @@ export const setBlueprintUsersSucceeded = (blueprint) => ({
   },
 });
 
+export const SET_BLUEPRINT_DEVICE = "SET_BLUEPRINT_DEVICE";
+export const setBlueprintDevice = (blueprint, device) => ({
+  type: SET_BLUEPRINT_DEVICE,
+  payload: {
+    blueprint,
+    device,
+  },
+});
+
 export const SET_BLUEPRINT_HOSTNAME = "SET_BLUEPRINT_HOSTNAME";
 export const setBlueprintHostname = (blueprint, hostname) => ({
   type: SET_BLUEPRINT_HOSTNAME,

--- a/core/sagas/blueprints.js
+++ b/core/sagas/blueprints.js
@@ -13,6 +13,7 @@ import {
   UPDATE_BLUEPRINT_COMPONENTS,
   SET_BLUEPRINT_USERS,
   setBlueprintUsersSucceeded,
+  SET_BLUEPRINT_DEVICE,
   SET_BLUEPRINT_HOSTNAME,
   setBlueprintHostnameSucceeded,
   SET_BLUEPRINT_DESCRIPTION,
@@ -210,6 +211,35 @@ function* setBlueprintUsers(action) {
   }
 }
 
+// convert between our stores blueprint object and the format that the weldr api expects
+function createWeldrBlueprint(blueprint) {
+  const weldrBlueprint = {
+    name: blueprint.name,
+    description: blueprint.description,
+    version: blueprint.version,
+    modules: blueprint.modules,
+    packages: blueprint.packages,
+    groups: blueprint.groups !== undefined ? blueprint.groups : [],
+    customizations: blueprint.customizations,
+  };
+  return weldrBlueprint;
+}
+
+function* setBlueprintDevice(action) {
+  try {
+    const { blueprint, device } = action.payload;
+    const blueprintToPost = createWeldrBlueprint(blueprint);
+    blueprintToPost.customizations = {
+      ...blueprintToPost.customizations,
+      installation_device: device,
+    };
+    yield call(composer.newBlueprint, blueprintToPost);
+  } catch (error) {
+    console.log("Error in setBlueprintDevice", error);
+    yield put(blueprintsFailure(error));
+  }
+}
+
 function* setBlueprintHostname(action) {
   try {
     const { blueprint, hostname } = action.payload;
@@ -361,6 +391,7 @@ export default function* () {
   yield takeEvery(CREATING_BLUEPRINT, createBlueprint);
   yield takeEvery(FETCHING_BLUEPRINT_CONTENTS, fetchBlueprintContents);
   yield takeEvery(SET_BLUEPRINT_USERS, setBlueprintUsers);
+  yield takeEvery(SET_BLUEPRINT_DEVICE, setBlueprintDevice);
   yield takeEvery(SET_BLUEPRINT_HOSTNAME, setBlueprintHostname);
   yield takeEvery(SET_BLUEPRINT_DESCRIPTION, setBlueprintDescription);
   yield takeEvery(DELETING_BLUEPRINT, deleteBlueprint);

--- a/pages/blueprint/index.css
+++ b/pages/blueprint/index.css
@@ -9,3 +9,15 @@
 .user-list th {
   padding-top: 0.375rem;
 }
+
+.form-customizations .col-sm-2,
+.form-customizations .col-sm-10,
+.form-customizations .col-sm-12 {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.form-customizations .form-horizontal .form-group {
+  margin-left: 0;
+  margin-right: 0;
+}

--- a/pages/blueprint/index.js
+++ b/pages/blueprint/index.js
@@ -7,6 +7,8 @@ import { FormattedMessage, defineMessages, injectIntl, intlShape } from "react-i
 import cockpit from "cockpit"; // eslint-disable-line import/no-unresolved
 import PropTypes from "prop-types";
 import { Tab, Tabs } from "patternfly-react";
+import { Button, Popover } from "@patternfly/react-core";
+import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
 import { Table, TableHeader, TableBody, TableVariant } from "@patternfly/react-table";
 import { connect } from "react-redux";
 import Link from "../../components/Link/Link";
@@ -117,6 +119,16 @@ const messages = defineMessages({
   },
   hostnameHelpEmpty: {
     defaultMessage: "If no hostname is provided, the hostname will be determined by the OS.",
+  },
+  deviceHelp: {
+    defaultMessage: "Enter valid device node such as /dev/sda1",
+  },
+  devicePopover: {
+    defaultMessage:
+      "The installation device is used by the RHEL for Edge Simplified Installer. It specifies which device the image will be installed onto.",
+  },
+  devicePopoverLabel: {
+    defaultMessage: "Installation device help",
   },
   deviceButtonLabel: {
     defaultMessage: "Edit installation device",
@@ -409,7 +421,7 @@ class BlueprintPage extends React.Component {
         >
           <Tab eventKey="customizations" title={formatMessage(messages.customizationsTitle)}>
             <div className="tab-container row">
-              <div className="col-sm-12">
+              <div className="form-customizations col-sm-12 pf-u-ml-md">
                 <div className="form-horizontal">
                   <div
                     id="input-hostname"
@@ -417,7 +429,9 @@ class BlueprintPage extends React.Component {
                     data-form="hostname"
                     onSubmit={() => this.handleEditHostname("commit")}
                   >
-                    <label className="col-sm-2 control-label">{formatMessage(messages.hostnameInputLabel)}</label>
+                    <label className="col-sm-2 control-label pf-u-text-align-left">
+                      {formatMessage(messages.hostnameInputLabel)}
+                    </label>
                     <TextInlineEdit
                       className="col-sm-10"
                       editVisible={editHostnameVisible}
@@ -432,8 +446,17 @@ class BlueprintPage extends React.Component {
                     />
                   </div>
                   <div className="form-group" id="input-device">
-                    <label className="col-sm-2 control-label">
+                    <label className="col-sm-2 control-label pf-u-text-align-left">
                       <FormattedMessage defaultMessage="Installation Device" />
+                      <Popover
+                        id="popover-installation-device"
+                        bodyContent={formatMessage(messages.devicePopover)}
+                        aria-label={formatMessage(messages.devicePopoverLabel)}
+                      >
+                        <Button variant="plain" aria-label={formatMessage(messages.devicePopoverLabel)}>
+                          <OutlinedQuestionCircleIcon />
+                        </Button>
+                      </Popover>
                     </label>
                     <TextInlineEdit
                       className="col-sm-10"
@@ -441,11 +464,12 @@ class BlueprintPage extends React.Component {
                       handleEdit={this.handleEditDeviceVisible}
                       buttonLabel={formatMessage(messages.deviceButtonLabel)}
                       inputLabel={formatMessage(messages.deviceInputLabel)}
+                      helpblock={formatMessage(messages.deviceHelp)}
                       value={device}
                     />
                   </div>
                   <div className="form-group user-list">
-                    <label className="col-sm-2 control-label">
+                    <label className="col-sm-2 control-label pf-u-text-align-left">
                       <FormattedMessage defaultMessage="Users" />
                     </label>
                     <div className="col-sm-10">

--- a/test/verify/check-custom
+++ b/test/verify/check-custom
@@ -54,7 +54,6 @@ class TestCustom(composerlib.ComposerCase):
 
     def testHostname(self):
         b = self.browser
-        m = self.machine
 
         self.login_and_go("/composer", superuser=True)
         b.wait_visible("#main")
@@ -65,37 +64,55 @@ class TestCustom(composerlib.ComposerCase):
         # set hostname to "openssh-server"
         b.click("button[aria-describedby=Hostname-help2]")
         b.set_input_text("input[aria-label=Hostname]", "hostname-openssh-server")
-        b.click(".form-control-pf-save")
+        b.click("#input-hostname .form-control-pf-save")
         b.wait_visible("span:contains(hostname-openssh-server)")
-        hostname = m.execute("""
-            composer-cli blueprints show openssh-server | grep hostname | awk -F '"' '{print $2}'
-            """).rstrip()
-        b.wait_visible("span:contains({})".format(hostname))
 
         # update hostname
-        b.click(".form-control-pf-value")
+        b.click("#input-hostname .form-control-pf-value")
         b.set_input_text("input[aria-label=Hostname]", "update-openssh-server")
-        b.key_press("\r")
+        b.click("#input-hostname .form-control-pf-save")
         b.wait_visible("span:contains(update-openssh-server)")
-        hostname = m.execute("""
-            composer-cli blueprints show openssh-server | grep hostname | awk -F '"' '{print $2}'
-            """).rstrip()
-        b.wait_visible("span:contains({})".format(hostname))
 
         # clicking x button will not update
-        b.click(".form-control-pf-value")
+        b.click("#input-hostname .form-control-pf-value")
         b.set_input_text("input[aria-label=Hostname]", "no-update-openssh-server")
-        b.click(".form-control-pf-cancel")
+        b.click("#input-hostname .form-control-pf-cancel")
         b.wait_visible("span:contains(update-openssh-server)")
-        hostname = m.execute("""
-            composer-cli blueprints show openssh-server | grep hostname | awk -F '"' '{print $2}'
-            """).rstrip()
-        b.wait_visible("span:contains({})".format(hostname))
 
         # invalid character, save button is disabled
-        b.click(".form-control-pf-value")
+        b.click("#input-hostname .form-control-pf-value")
         b.set_input_text("input[aria-label=Hostname]", "?")
-        b.wait_attr(".form-control-pf-save", "disabled", "")
+        b.wait_attr("#input-hostname .form-control-pf-save", "disabled", "")
+
+        # collect code coverage result
+        self.check_coverage()
+
+    def testDevice(self):
+        b = self.browser
+
+        self.login_and_go("/composer", superuser=True)
+        b.wait_visible("#main")
+
+        b.click("#openssh-server-name")
+        with b.wait_timeout(300):
+            b.click("#blueprint-tabs-tab-customizations")
+        # set device to "dev0"
+        b.click("#input-device .form-control-pf-value")
+        b.set_input_text("input[aria-label='Installation device']", "dev0")
+        b.click("#input-device .form-control-pf-save")
+        b.wait_visible("span:contains(dev0)")
+
+        # update device to "dev1"
+        b.click("#input-device .form-control-pf-value")
+        b.set_input_text("input[aria-label='Installation device']", "dev1")
+        b.click("#input-device .form-control-pf-save")
+        b.wait_visible("span:contains(dev1)")
+
+        # clicking x button will not update
+        b.click("#input-device .form-control-pf-value")
+        b.set_input_text("input[aria-label='Installation device']", "")
+        b.click("#input-device .form-control-pf-cancel")
+        b.wait_visible("span:contains(dev1)")
 
         # collect code coverage result
         self.check_coverage()


### PR DESCRIPTION
A user can now enter an installation device as a blueprint customization.

This is a very simple implementation. The functionality is a little clunky and follows the existing work for the hostname.

![Screenshot from 2021-10-01 18-22-54](https://user-images.githubusercontent.com/11712857/135654911-fa6e863b-3182-4089-a80e-e2e577c1eb92.png)
![Screenshot from 2021-10-01 18-22-37](https://user-images.githubusercontent.com/11712857/135654917-de06cce0-4189-47fa-a26f-038e89304786.png)
