### PR TITLE
Wizard: add support for edge-simplified-installer

### DIFF
--- a/components/Wizard/CreateImageUpload.js
+++ b/components/Wizard/CreateImageUpload.js
@@ -288,6 +288,9 @@ class CreateImageUploadModal extends React.Component {
     if (imageType === "ami") {
       return 6;
     }
+    if (imageType === "edge-simplified-installer") {
+      return 10;
+    }
     if (imageType === undefined) {
       return null;
     }
@@ -355,7 +358,8 @@ class CreateImageUploadModal extends React.Component {
     if (
       (this.state.imageType === "edge-installer" ||
         this.state.imageType === "rhel-edge-installer" ||
-        this.state.imageType === "edge-raw-image") &&
+        this.state.imageType === "edge-raw-image" ||
+        this.state.imageType === "edge-simplified-installer") &&
       !this.state.ostreeSettings.url
     ) {
       return false;

--- a/components/Wizard/ImageStep.js
+++ b/components/Wizard/ImageStep.js
@@ -714,7 +714,10 @@ class ImageStep extends React.PureComponent {
           {(imageType === "fedora-iot-commit" || imageType === "edge-commit" || imageType === "rhel-edge-commit") &&
             ostreeFields}
           {(imageType === "edge-container" || imageType === "rhel-edge-container") && ostreeFields}
-          {(imageType === "edge-installer" || imageType === "rhel-edge-installer" || imageType === "edge-raw-image") &&
+          {(imageType === "edge-installer" ||
+            imageType === "rhel-edge-installer" ||
+            imageType === "edge-raw-image" ||
+            imageType === "edge-simplified-installer") &&
             ostreeInstallerRawFields}
         </Form>
       </>

--- a/core/sagas/composes.js
+++ b/core/sagas/composes.js
@@ -145,6 +145,7 @@ function* fetchComposeTypes() {
       "edge-installer": "RHEL for Edge Installer (.iso)",
       "edge-raw-image": "RHEL for Edge Raw Image (.raw.xz)",
       "image-installer": "RHEL Installer (.iso)",
+      "edge-simplified-installer": "RHEL for Edge Simplified Installer (.iso)",
       vhd: "Microsoft Azure (.vhd)",
       vmdk: "VMWare VSphere (.vmdk)",
     };

--- a/test/verify/check-image
+++ b/test/verify/check-image
@@ -757,6 +757,40 @@ class TestImage(composerlib.ComposerCase):
         # collect code coverage result
         self.check_coverage()
 
+    @unittest.skipIf(os.environ.get("TEST_OS") != "rhel-8-5", "Does not support edge-simplified-installer image type")
+    def testEdgeSimplifiedInstaller(self):
+        b = self.browser
+
+        self.login_and_go("/composer", superuser=True)
+        b.wait_visible("#main")
+
+        # create image wizard
+        b.click("li[data-blueprint=httpd-server] #create-image-button")
+        b.wait_text("#create-image-upload-wizard #blueprint-name", "httpd-server")
+        b.wait_js_cond('ph_select("#image-type option").length > 1')
+        b.set_val("#image-type", "edge-simplified-installer")
+        # check url help button
+        b.click("button[aria-label='OSTree repo url help']")
+        b.text(".pf-c-popover__body")
+        b.wait_text(".pf-c-popover__body",
+                    "Provide the URL of the upstream repository. This repository is where the parent OSTree commit will be pulled from.")
+        b.click(".pf-c-popover__content button")
+        b.wait_not_present(".pf-c-popover__body")
+        # check ref help button
+        b.click("button[aria-label='OSTree ref help']")
+        b.text(".pf-c-popover__body")
+        b.wait_text(".pf-c-popover__body", "Provide the name of the branch for the content. If the ref does not already exist it will be created.")
+        b.click(".pf-c-popover__content button")
+        b.wait_not_present(".pf-c-popover__body")
+
+        # without a url entered the continue button should be disabled
+        b.wait_attr("#continue-button", "disabled", "")
+
+        self.allow_journal_messages(".*avc:  denied.*",
+                                    ".*audit: .*seresult=denied .*")
+        # collect code coverage result
+        self.check_coverage()
+
     def testOpenStack(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
The RHEL for Edge Simplified Installer is now supported by cockpit-composer. The user required fields are the same as for the Edge Installer. Testing is added.
![Screenshot from 2021-10-06 18-33-49](https://user-images.githubusercontent.com/11712857/136245934-51301a7b-0b79-4c23-af81-b069c0239078.png)
