### PR TITLE
utils: stop releasing into fedora 33

### DIFF
--- a/utils/cockpituous-release
+++ b/utils/cockpituous-release
@@ -17,12 +17,10 @@ job release-srpm -V
 
 # Do fedora builds for the tag, using tarball
 job release-koji rawhide
-job release-koji f33 
 job release-koji f34
 
 job release-github
 job release-copr @osbuild/cockpit-composer
 
 # Create a Bodhi update for stable Fedora releases
-job release-bodhi F33
 job release-bodhi F34


### PR DESCRIPTION
Fedora 35 has released so Fedora 33 will reach end of life on the 30th of November. The cockpit CI for fedora 33 has been removed so we have no need to continue releasing into is since 33 is EOL and no longer tested.