### PR TITLE
Bump cockpit test lib to fix Browser.logout() for cockpit 258

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,9 +152,8 @@ machine: bots
 	rsync -avR --exclude="bots/machine/machine_core/__pycache__/" bots/machine/testvm.py bots/machine/identity bots/machine/cloud-init.iso bots/machine/machine_core bots/lib test
 
 # checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
-# this needs a recent adjustment for firefox 77 and working with network-enabled tests
 test/common:
-	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 248
+	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git c3309b7a56099ec750ebb7ee72c9b1a9944de0b8
 	git checkout --force FETCH_HEAD -- test/common
 	git reset test/common
 

--- a/test/verify/check-blueprint
+++ b/test/verify/check-blueprint
@@ -67,7 +67,7 @@ class TestBlueprint(composerlib.ComposerCase):
         b.click(".toolbar-pf-action-right #cmpsr-btn-crt-blueprint")
         b.wait_visible("div[role=dialog] #cmpsr-modal-crt-blueprint")
         # empty name blueprint
-        b.set_input_text("#textInput-modal-markup", "openssh-server")
+        b.set_input_text("#textInput-modal-markup", "openssh-server", blur=False)
         b.key_press("\r")
         b.wait_text("#cmpsr-modal-crt-blueprint .alert-danger", "Specify a new blueprint name.")
         b.click("#cmpsr-modal-crt-blueprint button:contains('Cancel')")
@@ -83,7 +83,7 @@ class TestBlueprint(composerlib.ComposerCase):
         b.wait_visible("#main")
 
         # filter "openssh-server" blueprint
-        b.set_input_text("#filter-blueprints", "openssh")
+        b.set_input_text("#filter-blueprints", "openssh", blur=False)
         b.key_press("\r")
         b.wait_in_text(".filter-pf-active-label + .list-inline .label", "Name: openssh")
         b.wait_visible("#openssh-server-name")
@@ -93,7 +93,7 @@ class TestBlueprint(composerlib.ComposerCase):
         b.wait_not_present("p:contains('Active filters:')")
 
         # filter "httpd" will show three matched blueprints
-        b.set_input_text("#filter-blueprints", "httpd")
+        b.set_input_text("#filter-blueprints", "httpd", blur=False)
         b.key_press("\r")
         b.wait_in_text(".filter-pf-active-label + .list-inline .label", "Name: httpd")
         b.wait_not_present("#openssh-server-name")

--- a/test/verify/check-dependence
+++ b/test/verify/check-dependence
@@ -68,7 +68,7 @@ class TestDependence(composerlib.ComposerCase):
         b.wait_visible("a:contains('1 Pending Change')")
 
         # search for openssh-server pacakge
-        b.set_input_text("#cmpsr-blueprint-input-filter", "tmux")
+        b.set_input_text("#cmpsr-blueprint-input-filter", "tmux", blur=False)
         b.key_press("\r")
         with b.wait_timeout(120):
             b.click("#tmux-input")

--- a/test/verify/check-package
+++ b/test/verify/check-package
@@ -30,7 +30,7 @@ class TestPackage(composerlib.ComposerCase):
         b.click("button[aria-label='Go to previous page']")
         b.wait_visible("ul[aria-label='Available components'] li:nth-child(1)")
         # filter on avaliable components
-        b.set_input_text("#cmpsr-blueprint-input-filter", "cockpit-bridge")
+        b.set_input_text("#cmpsr-blueprint-input-filter", "cockpit-bridge", blur=False)
         b.key_press("\r")
         with b.wait_timeout(120):
             b.wait_text("#cockpit-bridge-input", "cockpit-bridge")
@@ -43,7 +43,7 @@ class TestPackage(composerlib.ComposerCase):
 
         # filter on blueprints component
         # filter by name
-        b.set_input_text("#filter-blueprints", "tmux")
+        b.set_input_text("#filter-blueprints", "tmux", blur=False)
         b.key_press("\r")
         b.wait_text("ul[data-list=components] li:nth-child(1) #tmux", "tmux")
         b.click(".cmpsr-panel__body--main .toolbar-pf-results button:contains('Clear all filters')")
@@ -55,7 +55,7 @@ class TestPackage(composerlib.ComposerCase):
         b.wait_in_text("#filterFieldTypeMenu", "Version")
         # input version is dynamic according to different OS release
         version = b.text("li[data-component=tmux] .cc-component__version strong")
-        b.set_input_text("#filter-blueprints", version)
+        b.set_input_text("#filter-blueprints", version, blur=False)
         b.key_press("\r")
         b.wait_text("ul[data-list=components] li:nth-child(1) #tmux", "tmux")
         b.click(".cmpsr-panel__body--main .toolbar-pf-results .pficon-close")
@@ -67,7 +67,7 @@ class TestPackage(composerlib.ComposerCase):
         b.wait_in_text("#filterFieldTypeMenu", "Release")
         # input release is dynamic according to different OS release
         release = b.text("li[data-component=tmux] .cc-component__release strong")
-        b.set_input_text("#filter-blueprints", release)
+        b.set_input_text("#filter-blueprints", release, blur=False)
         b.key_press("\r")
         b.wait_text("ul[data-list=components] li:nth-child(1) .cc-component__release strong",
                     release)
@@ -123,7 +123,7 @@ class TestPackage(composerlib.ComposerCase):
             b.wait_visible("ul[aria-label='Available components'] li:nth-child(1)")
 
         # search for openssh-server pacakge
-        b.set_input_text("#cmpsr-blueprint-input-filter", "cockpit-bridge")
+        b.set_input_text("#cmpsr-blueprint-input-filter", "cockpit-bridge", blur=False)
         b.key_press("\r")
         with b.wait_timeout(120):
             b.wait_text("#cockpit-bridge-input", "cockpit-bridge")
@@ -207,7 +207,7 @@ class TestPackage(composerlib.ComposerCase):
             b.wait_visible("ul[aria-label='Available components'] li:nth-child(1)")
 
         # search for openssh-server pacakge
-        b.set_input_text("#cmpsr-blueprint-input-filter", "cockpit-composer")
+        b.set_input_text("#cmpsr-blueprint-input-filter", "cockpit-composer", blur=False)
         b.key_press("\r")
         with b.wait_timeout(120):
             b.wait_text("#cockpit-composer-input", "cockpit-composer")

--- a/test/verify/check-service
+++ b/test/verify/check-service
@@ -57,7 +57,7 @@ class TestService(composerlib.ComposerCase):
         with b.wait_timeout(300):
             b.wait_visible("ul[data-list=inputs]")
         # search for openssh-server pacakge
-        b.set_input_text("#cmpsr-blueprint-input-filter", "openssh-server")
+        b.set_input_text("#cmpsr-blueprint-input-filter", "openssh-server", blur=False)
         b.key_press("\r")
         with b.wait_timeout(120):
             b.wait_text("#openssh-server-input", "openssh-server")


### PR DESCRIPTION
The shell DOM changed in Cockpit 258. Pick up the Browser.logout()
change which can deal with both old and new shell versions.

Version 257 changed the set_input_text() API: The input line now does
not stay focused implicitly:
https://github.com/cockpit-project/cockpit/commit/9b86016ce13
Adjust tests to explicitly disable the blurring if a subsequent
key_press() wants to amend the input line value.

---

This blocks the recent image refreshes like https://github.com/cockpit-project/bots/pull/2669