### PR TITLE
Bump cockpit test lib to 259

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ machine: bots
 
 # checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
 test/common:
-	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git c3309b7a56099ec750ebb7ee72c9b1a9944de0b8
+	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 259
 	git checkout --force FETCH_HEAD -- test/common
 	git reset test/common
 


### PR DESCRIPTION
The shell DOM changed in Cockpit 258. Pick up the Browser.logout()
change which can deal with both old and new shell versions.

---

This should fix the test regression in https://github.com/cockpit-project/bots/pull/2721