### PR TITLE
[r8.5] test/run: create overlay dir, fix for latest firefox

### DIFF
--- a/test/run
+++ b/test/run
@@ -8,6 +8,7 @@ fi
 
 # overlays are too big for bot's 10GB /tmp tmpfs
 TEST_OVERLAY_DIR="$(pwd)/tmp/run"
+mkdir -p $TEST_OVERLAY_DIR
 
 make check
 


### PR DESCRIPTION
The TEST_OVERLAY_DIR must be manually created per:
https://github.com/cockpit-project/bots/commit/16aa791cd

Cherry-picked from main commit dafa4d356bd173895

---

Spotted in https://github.com/cockpit-project/bots/pull/2964 - This is just a backport.