### PR TITLE
Revert "workflows: release tags now start with a v"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ on:
   push:
     tags:
       # this is a glob, not a regexp
-      - 'v*'
+      - '[0-9]*'
 jobs:
   cockpituous:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
This reverts commit 04030c4f73481cd5c11a03f2d82cb4323da80da3.