### PR TITLE
test: Disable TestImage.testOSTree{Commit,Container}

### DIFF
--- a/test/verify/check-image
+++ b/test/verify/check-image
@@ -505,6 +505,7 @@ class TestImage(composerlib.ComposerCase):
         # collect code coverage result
         self.check_coverage()
 
+    @unittest.skip("FIXME: Broken")
     def testOSTreeCommit(self):
         b = self.browser
         m = self.machine
@@ -585,6 +586,7 @@ class TestImage(composerlib.ComposerCase):
 
     # Parse the name of the distro to know if it is any version of rhel/fedora
     @unittest.skipIf(os.environ.get("TEST_OS").split('-')[0] != "rhel", "Does not support ostree container image type")
+    @unittest.skip("FIXME: Broken")
     def testOSTreeContainer(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
These two tests have constantly failed for several months. They cause
blocked VM image refreshes, test timeouts (so that the other tests
often don't run), and block the infra.

----

This is a desperate measure, but these two tests currently don't help anyone. We know that either OSTree builds or the tests are broken, and it needs some maintainer effort to look at them.

See e.g. #1411 for a recent example.