### PR TITLE
Update react-intl

### DIFF
--- a/components/EmptyState/EmptyStateInactive.js
+++ b/components/EmptyState/EmptyStateInactive.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { FormattedMessage, defineMessages, injectIntl, intlShape } from "react-intl";
+import { FormattedMessage, defineMessages, injectIntl } from "react-intl";
 import cockpit from "cockpit";
 import { Alert, Button, OverlayTrigger, Tooltip } from "patternfly-react";
 import { EmptyStateSecondaryActions, EmptyStatePrimary } from "@patternfly/react-core";
@@ -139,7 +139,7 @@ class EmptyStateInactive extends React.Component {
 
 EmptyStateInactive.propTypes = {
   fetchingBlueprints: PropTypes.func,
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
 };
 
 EmptyStateInactive.defaultProps = {

--- a/components/Form/TextInlineEdit.js
+++ b/components/Form/TextInlineEdit.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { defineMessages, injectIntl, intlShape } from "react-intl";
+import { defineMessages, injectIntl } from "react-intl";
 import PropTypes from "prop-types";
 
 const messages = defineMessages({
@@ -164,7 +164,7 @@ TextInlineEdit.propTypes = {
   value: PropTypes.string,
   helpblock: PropTypes.string,
   helpblockNoValue: PropTypes.string,
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
 };
 
 TextInlineEdit.defaultProps = {

--- a/components/ListView/BlueprintContents.js
+++ b/components/ListView/BlueprintContents.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { defineMessages, injectIntl, intlShape, FormattedMessage } from "react-intl";
+import { defineMessages, injectIntl, FormattedMessage } from "react-intl";
 import PropTypes from "prop-types";
 import { DataList, Alert } from "@patternfly/react-core";
 import { Tabs, Tab } from "patternfly-react";
@@ -146,7 +146,7 @@ BlueprintContents.propTypes = {
   dependencies: PropTypes.arrayOf(PropTypes.object),
   handleComponentDetails: PropTypes.func,
   handleRemoveComponent: PropTypes.func,
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
   noEditComponent: PropTypes.bool,
   filterClearValues: PropTypes.func,
   filterValues: PropTypes.arrayOf(PropTypes.object),

--- a/components/ListView/BlueprintsDataList.js
+++ b/components/ListView/BlueprintsDataList.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { defineMessages, injectIntl, intlShape, FormattedMessage } from "react-intl";
+import { defineMessages, injectIntl, FormattedMessage } from "react-intl";
 import PropTypes from "prop-types";
 import { DataList, DataListItem, DataListItemRow, DataListCell, DataListItemCells } from "@patternfly/react-core";
 import { PficonTemplateIcon } from "@patternfly/react-icons";
@@ -83,7 +83,7 @@ BlueprintsDataList.propTypes = {
     setNotifications: PropTypes.func,
   }),
   ariaLabel: PropTypes.string,
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
 };
 
 BlueprintsDataList.defaultProps = {

--- a/components/ListView/ComponentDetailsView.js
+++ b/components/ListView/ComponentDetailsView.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { FormattedMessage, defineMessages, injectIntl, intlShape } from "react-intl";
+import { FormattedMessage, defineMessages, injectIntl } from "react-intl";
 import PropTypes from "prop-types";
 import { Tabs, Tab } from "patternfly-react";
 import { Tooltip, TooltipPosition } from "@patternfly/react-core";
@@ -370,7 +370,7 @@ ComponentDetailsView.propTypes = {
   setSelectedInput: PropTypes.func,
   setSelectedInputParent: PropTypes.func,
   clearSelectedInput: PropTypes.func,
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
 };
 
 ComponentDetailsView.defaultProps = {

--- a/components/ListView/ComponentInputs.js
+++ b/components/ListView/ComponentInputs.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { defineMessages, injectIntl, intlShape } from "react-intl";
+import { defineMessages, injectIntl } from "react-intl";
 import PropTypes from "prop-types";
 import {
   DataList,
@@ -116,7 +116,7 @@ ComponentInputs.propTypes = {
   handleComponentDetails: PropTypes.func,
   handleAddComponent: PropTypes.func,
   handleRemoveComponent: PropTypes.func,
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
 };
 
 ComponentInputs.defaultProps = {

--- a/components/ListView/ComponentSummaryList.js
+++ b/components/ListView/ComponentSummaryList.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { defineMessages, injectIntl, intlShape, FormattedMessage } from "react-intl";
+import { defineMessages, injectIntl, FormattedMessage } from "react-intl";
 import PropTypes from "prop-types";
 import {
   Split,
@@ -84,7 +84,7 @@ class ComponentSummaryList extends React.Component {
 ComponentSummaryList.propTypes = {
   listItems: PropTypes.arrayOf(PropTypes.object),
   parent: PropTypes.string,
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
 };
 
 ComponentSummaryList.defaultProps = {

--- a/components/ListView/ComponentTypeIcons.js
+++ b/components/ListView/ComponentTypeIcons.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { defineMessages, injectIntl, intlShape } from "react-intl";
+import { defineMessages, injectIntl } from "react-intl";
 import PropTypes from "prop-types";
 import { Tooltip, TooltipPosition } from "@patternfly/react-core";
 
@@ -54,7 +54,7 @@ ComponentTypeIcons.propTypes = {
   compDetails: PropTypes.bool,
   componentInBlueprint: PropTypes.bool,
   isSelected: PropTypes.bool,
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
 };
 
 ComponentTypeIcons.defaultProps = {

--- a/components/ListView/ComponentsDataListItem.js
+++ b/components/ListView/ComponentsDataListItem.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { defineMessages, injectIntl, intlShape, FormattedMessage } from "react-intl";
+import { defineMessages, injectIntl, FormattedMessage } from "react-intl";
 import PropTypes from "prop-types";
 import {
   DataListItem,
@@ -198,7 +198,7 @@ ComponentsDataListItem.propTypes = {
   handleRemoveComponent: PropTypes.func,
   noEditComponent: PropTypes.bool,
   fetchDetails: PropTypes.func,
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
 };
 
 ComponentsDataListItem.defaultProps = {

--- a/components/ListView/ListItemImages.js
+++ b/components/ListView/ListItemImages.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { FormattedMessage, defineMessages, injectIntl, intlShape } from "react-intl";
+import { FormattedMessage, defineMessages, injectIntl } from "react-intl";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import {
@@ -398,7 +398,7 @@ ListItemImages.propTypes = {
   setModalDeleteImageState: PropTypes.func,
   setModalDeleteImageVisible: PropTypes.func,
   downloadUrl: PropTypes.string,
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
 };
 
 ListItemImages.defaultProps = {

--- a/components/ListView/ListItemUploads.js
+++ b/components/ListView/ListItemUploads.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { defineMessages, injectIntl, intlShape } from "react-intl";
+import { defineMessages, injectIntl } from "react-intl";
 import PropTypes from "prop-types";
 import { Button, DataListItem, DataListItemRow, DataListCell, DataListItemCells } from "@patternfly/react-core";
 import { CaretDownIcon, ServiceIcon } from "@patternfly/react-icons";
@@ -169,7 +169,7 @@ ListItemUploads.propTypes = {
     status: PropTypes.string,
     uuid: PropTypes.string,
   }),
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
 };
 
 ListItemUploads.defaultProps = {

--- a/components/ListView/SourcesListItem.js
+++ b/components/ListView/SourcesListItem.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { FormattedMessage, defineMessages, injectIntl, intlShape } from "react-intl";
+import { FormattedMessage, defineMessages, injectIntl } from "react-intl";
 import { Spinner } from "patternfly-react";
 
 const messages = defineMessages({
@@ -130,7 +130,7 @@ SourcesListItem.propTypes = {
   fetching: PropTypes.string,
   edit: PropTypes.func,
   remove: PropTypes.func,
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
 };
 
 SourcesListItem.defaultProps = {

--- a/components/Modal/ManageSources.js
+++ b/components/Modal/ManageSources.js
@@ -4,7 +4,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { FormattedMessage, defineMessages, injectIntl, intlShape } from "react-intl";
+import { FormattedMessage, defineMessages, injectIntl } from "react-intl";
 import { Alert, Spinner } from "patternfly-react";
 import { Modal, ModalVariant, Title } from "@patternfly/react-core";
 import SourcesListItem from "../ListView/SourcesListItem";
@@ -469,7 +469,7 @@ ManageSources.propTypes = {
   removeModalManageSourcesEntry: PropTypes.func,
   addModalManageSourcesEntry: PropTypes.func,
   modalManageSourcesFailure: PropTypes.func,
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
 };
 
 ManageSources.defaultProps = {
@@ -490,7 +490,7 @@ ManageSourcesModal.propTypes = {
   addSource: PropTypes.func,
   clearError: PropTypes.func,
   close: PropTypes.func,
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
 };
 
 ManageSourcesModal.defaultProps = {

--- a/components/Modal/PendingChanges.js
+++ b/components/Modal/PendingChanges.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { FormattedMessage, defineMessages, injectIntl, intlShape } from "react-intl";
+import { FormattedMessage, defineMessages, injectIntl } from "react-intl";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { Button, OverlayTrigger, Popover, Icon, Alert } from "patternfly-react";
@@ -314,7 +314,7 @@ PendingChanges.propTypes = {
   handleHideModal: PropTypes.func,
   setBlueprintComment: PropTypes.func,
   handleCommit: PropTypes.func,
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
 };
 
 PendingChanges.defaultProps = {

--- a/components/Modal/UserAccount.js
+++ b/components/Modal/UserAccount.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { FormattedMessage, defineMessages, injectIntl, intlShape } from "react-intl";
+import { FormattedMessage, defineMessages, injectIntl } from "react-intl";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { Button, Checkbox, Form, FormGroup, Modal, ModalVariant, TextInput, TextArea } from "@patternfly/react-core";
@@ -392,7 +392,7 @@ UserAccount.propTypes = {
   blueprintID: PropTypes.string,
   users: PropTypes.arrayOf(PropTypes.object),
   setBlueprintUsers: PropTypes.func,
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
 };
 
 UserAccount.defaultProps = {

--- a/components/Notifications/Notifications.js
+++ b/components/Notifications/Notifications.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { defineMessages, FormattedMessage, injectIntl, intlShape } from "react-intl";
+import { defineMessages, FormattedMessage, injectIntl } from "react-intl";
 import { connect } from "react-redux";
 import PropTypes from "prop-types";
 import { Alert, AlertActionCloseButton, AlertGroup } from "@patternfly/react-core";
@@ -169,7 +169,7 @@ class Notifications extends React.PureComponent {
 Notifications.propTypes = {
   alerts: PropTypes.arrayOf(PropTypes.object),
   alertDelete: PropTypes.func,
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
 };
 
 Notifications.defaultProps = {

--- a/components/Toolbar/FilterInput.js
+++ b/components/Toolbar/FilterInput.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Filter } from "patternfly-react";
-import { defineMessages, injectIntl, intlShape } from "react-intl";
+import { defineMessages, injectIntl } from "react-intl";
 
 const messages = defineMessages({
   filterNameTitle: {
@@ -157,7 +157,7 @@ FilterInput.propTypes = {
     filterValues: PropTypes.arrayOf(PropTypes.object),
   }),
   filterAddValue: PropTypes.func,
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
 };
 
 FilterInput.defaultProps = {

--- a/components/Toolbar/ToolbarLayout.js
+++ b/components/Toolbar/ToolbarLayout.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { defineMessages, FormattedMessage, intlShape, injectIntl } from "react-intl";
+import { defineMessages, FormattedMessage, injectIntl } from "react-intl";
 import PropTypes from "prop-types";
 import { Filter, Toolbar } from "patternfly-react";
 
@@ -84,7 +84,7 @@ ToolbarLayout.propTypes = {
   filterRemoveValue: PropTypes.func,
   filterClearValues: PropTypes.func,
   children: PropTypes.node,
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
 };
 
 ToolbarLayout.defaultProps = {

--- a/components/Wizard/AWSAuthStep.js
+++ b/components/Wizard/AWSAuthStep.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Button, Form, Popover, Text, TextInput } from "@patternfly/react-core";
 import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
-import { FormattedMessage, defineMessages, injectIntl, intlShape } from "react-intl";
+import { FormattedMessage, defineMessages, injectIntl } from "react-intl";
 import PropTypes from "prop-types";
 
 const ariaLabels = defineMessages({
@@ -105,7 +105,7 @@ class AWSAuthStep extends React.PureComponent {
 }
 
 AWSAuthStep.propTypes = {
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
   setUploadSettings: PropTypes.func,
   uploadSettings: PropTypes.object,
 };

--- a/components/Wizard/AWSDestinationStep.js
+++ b/components/Wizard/AWSDestinationStep.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Button, Form, Popover, Text, TextInput } from "@patternfly/react-core";
 import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
-import { FormattedMessage, defineMessages, injectIntl, intlShape } from "react-intl";
+import { FormattedMessage, defineMessages, injectIntl } from "react-intl";
 import PropTypes from "prop-types";
 
 const ariaLabels = defineMessages({
@@ -145,7 +145,7 @@ class AWSDestinationStep extends React.PureComponent {
 }
 
 AWSDestinationStep.propTypes = {
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
   imageName: PropTypes.string,
   setUploadSettings: PropTypes.func,
   setImageName: PropTypes.func,

--- a/components/Wizard/AzureAuthStep.js
+++ b/components/Wizard/AzureAuthStep.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Button, Form, Popover, Text, TextInput } from "@patternfly/react-core";
 import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
-import { FormattedMessage, defineMessages, injectIntl, intlShape } from "react-intl";
+import { FormattedMessage, defineMessages, injectIntl } from "react-intl";
 import PropTypes from "prop-types";
 
 const ariaLabels = defineMessages({
@@ -117,7 +117,7 @@ class AzureAuthStep extends React.PureComponent {
 }
 
 AzureAuthStep.propTypes = {
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
   setUploadSettings: PropTypes.func,
   uploadSettings: PropTypes.object,
 };

--- a/components/Wizard/AzureDestinationStep.js
+++ b/components/Wizard/AzureDestinationStep.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Button, Form, Popover, Text, TextInput } from "@patternfly/react-core";
 import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
-import { FormattedMessage, defineMessages, injectIntl, intlShape } from "react-intl";
+import { FormattedMessage, defineMessages, injectIntl } from "react-intl";
 import PropTypes from "prop-types";
 
 const ariaLabels = defineMessages({
@@ -113,7 +113,7 @@ class AzureDestinationStep extends React.PureComponent {
 }
 
 AzureDestinationStep.propTypes = {
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
   imageName: PropTypes.string,
   setUploadSettings: PropTypes.func,
   setImageName: PropTypes.func,

--- a/components/Wizard/CreateImageUpload.js
+++ b/components/Wizard/CreateImageUpload.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { Button, Wizard, WizardContextConsumer, WizardFooter } from "@patternfly/react-core";
-import { defineMessages, FormattedMessage, injectIntl, intlShape } from "react-intl";
+import { defineMessages, FormattedMessage, injectIntl } from "react-intl";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { v4 as uuid } from "uuid";
@@ -623,7 +623,7 @@ CreateImageUpload.propTypes = {
     version: PropTypes.string,
     workspacePendingChanges: PropTypes.arrayOf(PropTypes.object),
   }),
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
 };
 
 CreateImageUpload.defaultProps = {
@@ -650,7 +650,7 @@ CreateImageUploadModal.propTypes = {
   imageTypes: PropTypes.arrayOf(PropTypes.object),
   fetchingComposeTypes: PropTypes.func,
   setBlueprint: PropTypes.func,
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
   startCompose: PropTypes.func,
   close: PropTypes.func.isRequired,
   isOpen: PropTypes.bool,

--- a/components/Wizard/ImageStep.js
+++ b/components/Wizard/ImageStep.js
@@ -18,7 +18,7 @@ import {
   ExclamationTriangleIcon,
   OutlinedQuestionCircleIcon,
 } from "@patternfly/react-icons";
-import { FormattedMessage, defineMessages, injectIntl, intlShape } from "react-intl";
+import { FormattedMessage, defineMessages, injectIntl } from "react-intl";
 import PropTypes from "prop-types";
 
 const ariaLabels = defineMessages({
@@ -815,7 +815,7 @@ class ImageStep extends React.PureComponent {
 ImageStep.propTypes = {
   blueprint: PropTypes.object,
   handleUploadService: PropTypes.func,
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
   imageType: PropTypes.string,
   imageTypes: PropTypes.arrayOf(PropTypes.object),
   imageSize: PropTypes.number,

--- a/components/Wizard/OCIAuthStep.js
+++ b/components/Wizard/OCIAuthStep.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Button, Form, Popover, Text, TextInput, FileUpload } from "@patternfly/react-core";
 import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
-import { FormattedMessage, defineMessages, injectIntl, intlShape } from "react-intl";
+import { FormattedMessage, defineMessages, injectIntl } from "react-intl";
 import PropTypes from "prop-types";
 
 const ariaLabels = defineMessages({
@@ -171,7 +171,7 @@ class OCIAuthStep extends React.PureComponent {
 }
 
 OCIAuthStep.propTypes = {
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
   setUploadSettings: PropTypes.func,
   uploadSettings: PropTypes.object,
 };

--- a/components/Wizard/OCIDestinationStep.js
+++ b/components/Wizard/OCIDestinationStep.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Button, Form, Popover, Text, TextInput } from "@patternfly/react-core";
 import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
-import { FormattedMessage, defineMessages, injectIntl, intlShape } from "react-intl";
+import { FormattedMessage, defineMessages, injectIntl } from "react-intl";
 import PropTypes from "prop-types";
 
 const ariaLabels = defineMessages({
@@ -261,7 +261,7 @@ class OCIDestinationStep extends React.PureComponent {
 }
 
 OCIDestinationStep.propTypes = {
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
   imageName: PropTypes.string,
   setUploadSettings: PropTypes.func,
   setImageName: PropTypes.func,

--- a/components/Wizard/ReviewStep.js
+++ b/components/Wizard/ReviewStep.js
@@ -17,7 +17,7 @@ import {
   ExclamationTriangleIcon,
   OutlinedQuestionCircleIcon,
 } from "@patternfly/react-icons";
-import { FormattedMessage, defineMessages, injectIntl, intlShape } from "react-intl";
+import { FormattedMessage, defineMessages, injectIntl } from "react-intl";
 import PropTypes from "prop-types";
 
 const ariaLabels = defineMessages({
@@ -474,7 +474,7 @@ class ReviewStep extends React.PureComponent {
 }
 
 ReviewStep.propTypes = {
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
   imageName: PropTypes.string,
   imageType: PropTypes.string,
   imageTypes: PropTypes.arrayOf(PropTypes.object),

--- a/components/Wizard/VMWareDestinationStep.js
+++ b/components/Wizard/VMWareDestinationStep.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Button, Form, Popover, Text, TextInput } from "@patternfly/react-core";
 import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
-import { FormattedMessage, defineMessages, injectIntl, intlShape } from "react-intl";
+import { FormattedMessage, defineMessages, injectIntl } from "react-intl";
 import PropTypes from "prop-types";
 
 const ariaLabels = defineMessages({
@@ -201,7 +201,7 @@ class VMWareDestinationStep extends React.PureComponent {
 }
 
 VMWareDestinationStep.propTypes = {
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
   imageName: PropTypes.string,
   setUploadSettings: PropTypes.func,
   setImageName: PropTypes.func,

--- a/main.js
+++ b/main.js
@@ -9,8 +9,7 @@ import "./lib/patternfly/patternfly-cockpit.scss";
 
 import React from "react";
 import ReactDOM from "react-dom";
-import { addLocaleData, IntlProvider } from "react-intl";
-import enLocaleData from "react-intl/locale-data/en";
+import { IntlProvider } from "react-intl";
 import FastClick from "fastclick";
 import { Provider } from "react-redux";
 import "@patternfly/patternfly/patternfly-addons.css";
@@ -26,14 +25,6 @@ import history from "./core/history";
 
 // Intialize any necessary locale data, and load translated messages
 const translations = require("./build/translations.json");
-
-const languages = [...new Set(Object.keys(translations).map((lang) => lang.split("_")[0]))];
-for (const lang of languages) {
-  const localData = require(`react-intl/locale-data/${lang}`); // eslint-disable-line import/no-dynamic-require
-  addLocaleData(localData);
-}
-// still need english
-addLocaleData(enLocaleData);
 
 const routes = require("./routes.json");
 // Loaded with utils/routes-loader.js

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prop-types": "15.8.0",
     "react": "16.14.0",
     "react-dom": "16.14.0",
-    "react-intl": "^3.12.1",
+    "react-intl": "4.7.6",
     "react-redux": "5.1.2",
     "redux": "3.7.2",
     "redux-saga": "0.15.6",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prop-types": "15.8.0",
     "react": "16.14.0",
     "react-dom": "16.14.0",
-    "react-intl": "4.7.6",
+    "react-intl": "^5.25.1",
     "react-redux": "5.1.2",
     "redux": "3.7.2",
     "redux-saga": "0.15.6",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prop-types": "15.8.0",
     "react": "16.14.0",
     "react-dom": "16.14.0",
-    "react-intl": "2.9.0",
+    "react-intl": "^3.12.1",
     "react-redux": "5.1.2",
     "redux": "3.7.2",
     "redux-saga": "0.15.6",

--- a/pages/blueprint/index.js
+++ b/pages/blueprint/index.js
@@ -3,7 +3,7 @@
 /* eslint-disable jsx-a11y/label-has-associated-control */
 
 import React from "react";
-import { FormattedMessage, defineMessages, injectIntl, intlShape } from "react-intl";
+import { FormattedMessage, defineMessages, injectIntl } from "react-intl";
 import cockpit from "cockpit"; // eslint-disable-line import/no-unresolved
 import PropTypes from "prop-types";
 import { Tab, Tabs } from "patternfly-react";
@@ -705,7 +705,7 @@ BlueprintPage.propTypes = {
     url: PropTypes.string,
   }),
   blueprintContentsFetching: PropTypes.bool,
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
 };
 
 BlueprintPage.defaultProps = {

--- a/pages/blueprintEdit/index.js
+++ b/pages/blueprintEdit/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { FormattedMessage, defineMessages, injectIntl, intlShape } from "react-intl";
+import { FormattedMessage, defineMessages, injectIntl } from "react-intl";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { Pagination, PaginationVariant, TextInput } from "@patternfly/react-core";
@@ -770,7 +770,7 @@ EditBlueprintPage.propTypes = {
     url: PropTypes.string,
   }),
   blueprintContentsFetching: PropTypes.bool,
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
 };
 
 EditBlueprintPage.defaultProps = {

--- a/pages/blueprints/index.js
+++ b/pages/blueprints/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { FormattedMessage, defineMessages, injectIntl, intlShape } from "react-intl";
+import { FormattedMessage, defineMessages, injectIntl } from "react-intl";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { Button, EmptyStatePrimary } from "@patternfly/react-core";
@@ -166,7 +166,7 @@ BlueprintsPage.propTypes = {
     url: PropTypes.string,
   }),
   blueprintsLoading: PropTypes.bool,
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
 };
 
 BlueprintsPage.defaultProps = {

--- a/pages/error/index.js
+++ b/pages/error/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { FormattedMessage, defineMessages, injectIntl, intlShape } from "react-intl";
+import { FormattedMessage, defineMessages, injectIntl } from "react-intl";
 import PropTypes from "prop-types";
 import history from "../../core/history";
 import Link from "../../components/Link/Link";
@@ -86,7 +86,7 @@ ErrorPage.propTypes = {
   error: PropTypes.shape({
     status: PropTypes.number,
   }),
-  intl: intlShape.isRequired,
+  intl: PropTypes.object.isRequired,
 };
 
 ErrorPage.defaultProps = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -84,6 +84,17 @@ module.exports = {
           options: babelConfig,
         },
       },
+      {
+        include: [
+          path.join(__dirname, "node_modules/react-intl"),
+          path.join(__dirname, "node_modules/intl-messageformat"),
+          path.join(__dirname, "node_modules/intl-messageformat-parser"),
+        ],
+        use: {
+          loader: "babel-loader",
+          options: babelConfig,
+        },
+      },
       // add type: "javascript/auto" when transforming JSON via loader to JS
       {
         include: [path.resolve(__dirname, "./routes.json")],


### PR DESCRIPTION
React-intl is upgraded from v2 to v5. This is now the most recent release. This should allow us to accurately follow the documentation for react-intl going forward as well as this will not block upgrading React.