### PR TITLE
Wizard: only pass blueprint name

### DIFF
--- a/components/ListView/BlueprintsDataList.js
+++ b/components/ListView/BlueprintsDataList.js
@@ -48,7 +48,7 @@ class BlueprintsDataList extends React.PureComponent {
                   <FormattedMessage defaultMessage="Edit packages" />
                 </Link>
                 {/* <CreateImageUpload blueprint={blueprint} layout={layout} /> */}
-                <CreateImageWizard blueprint={blueprint} />
+                <CreateImageWizard blueprintName={blueprint.name} />
                 <div className="dropdown pull-right dropdown-kebab-pf">
                   <button
                     className="btn btn-link dropdown-toggle"

--- a/components/Wizard/CreateImageWizard.js
+++ b/components/Wizard/CreateImageWizard.js
@@ -28,7 +28,7 @@ const CreateImageWizard = (props) => {
 
     // startCompose(props.blueprint.name, composeType, imageSize, ostree, upload);
     props.startCompose(
-      props.blueprint.name,
+      props.blueprintName,
       formValues["image-output-type"],
       formValues["image-size"],
       undefined,
@@ -62,7 +62,7 @@ const CreateImageWizard = (props) => {
               },
             ],
           }}
-          blueprint={props.blueprint}
+          blueprintName={props.blueprintName}
           imageTypes={props.imageTypes}
         />
       )}

--- a/components/Wizard/ImageCreator.js
+++ b/components/Wizard/ImageCreator.js
@@ -27,7 +27,7 @@ const ImageCreator = ({
         ...customComponentMapper,
         "blueprint-name": {
           component: BlueprintName,
-          blueprint: props.blueprint,
+          blueprintName: props.blueprintName,
         },
         "image-output-select": {
           component: ImageOutputSelect,
@@ -35,7 +35,7 @@ const ImageCreator = ({
         },
         review: {
           component: Review,
-          blueprint: props.blueprint,
+          blueprintName: props.blueprintName,
         },
       }}
       onCancel={onClose}

--- a/components/Wizard/formComponents/BlueprintName.js
+++ b/components/Wizard/formComponents/BlueprintName.js
@@ -17,7 +17,7 @@ const BlueprintName = (props) => {
         </Popover>
       }
     >
-      <Text>{props.blueprint.name}</Text>
+      <Text>{props.blueprintName}</Text>
     </FormGroup>
   );
 };

--- a/components/Wizard/formComponents/Review.js
+++ b/components/Wizard/formComponents/Review.js
@@ -21,7 +21,7 @@ const Review = (props) => {
       <TextContent>
         <TextList component={TextListVariants.dl}>
           <TextListItem component={TextListItemVariants.dt}>Blueprint name</TextListItem>
-          <TextListItem component={TextListItemVariants.dd}>{props.blueprint.name}</TextListItem>
+          <TextListItem component={TextListItemVariants.dd}>{props.blueprintName}</TextListItem>
           <TextListItem component={TextListItemVariants.dt}>Output type</TextListItem>
           <TextListItem component={TextListItemVariants.dd}>{getState()?.values?.["image-output-type"]}</TextListItem>
           <TextListItem component={TextListItemVariants.dt}>Image size</TextListItem>


### PR DESCRIPTION
The entire blueprint is not needed by the Wizard. Passing the whole
blueprint will also trigger DOM refreshes as the blueprint contents
change. Only depending on the blueprint name prevents this as well as
reduces the passing of unnecessary data.