### PR TITLE
Add ostree support

### DIFF
--- a/components/Wizard/CreateImageWizard.js
+++ b/components/Wizard/CreateImageWizard.js
@@ -16,9 +16,13 @@ import {
   vmwareDest,
   ociAuth,
   ociDest,
+  ostreeSettings,
   details,
   review,
 } from "./steps";
+
+import { ostreeValidator } from "./validators";
+
 import "./CreateImageWizard.css";
 
 const CreateImageWizard = (props) => {
@@ -95,11 +99,28 @@ const CreateImageWizard = (props) => {
       }
     }
 
+    let ostreeSettings;
+    const ostreeImageTypes = [
+      "fedora-iot-commit",
+      "edge-commit",
+      "edge-container",
+      "edge-installer",
+      "edge-raw-image",
+      "edge-simplified-installer",
+    ];
+    if (ostreeImageTypes.includes(formValues["image-output-type"])) {
+      ostreeSettings = {
+        parent: formValues["ostree-parent-commit"],
+        ref: formValues["ostree-ref"],
+        url: formValues["ostree-repo-url"],
+      };
+    }
+
     props.startCompose(
       props.blueprintName,
       formValues["image-output-type"],
       formValues["image-size"],
-      undefined,
+      ostreeSettings,
       uploadSettings
     );
     setIsWizardOpen(false);
@@ -114,6 +135,7 @@ const CreateImageWizard = (props) => {
         <ImageCreator
           onClose={handleClose}
           onSubmit={(formValues) => handleSubmit(formValues)}
+          customValidatorMapper={{ ostreeValidator }}
           schema={{
             fields: [
               {
@@ -136,6 +158,7 @@ const CreateImageWizard = (props) => {
                   ociDest,
                   vmwareAuth,
                   vmwareDest,
+                  ostreeSettings,
                   details,
                   review,
                 ],

--- a/components/Wizard/ImageCreator.js
+++ b/components/Wizard/ImageCreator.js
@@ -24,6 +24,7 @@ const ImageCreator = ({
       schema={schema}
       FormTemplate={(props) => <Pf4FormTemplate {...props} showFormControls={false} />}
       onSubmit={(formValues) => onSubmit(formValues)}
+      validatorMapper={{ ...customValidatorMapper }}
       componentMapper={{
         ...componentMapper,
         ...customComponentMapper,

--- a/components/Wizard/formComponents/FormGroupCustom.js
+++ b/components/Wizard/formComponents/FormGroupCustom.js
@@ -1,0 +1,70 @@
+import React from "react";
+import { FormGroup as Pf4FormGroup, TextContent, Text } from "@patternfly/react-core";
+import PropTypes from "prop-types";
+
+const showError = ({ error, touched, warning, submitError }, validateOnMount) => {
+  if ((touched || validateOnMount) && error) {
+    return { validated: "error" };
+  }
+
+  if ((touched || validateOnMount) && submitError) {
+    return { validated: "error" };
+  }
+
+  if ((touched || validateOnMount) && warning) {
+    return { validated: "warning" };
+  }
+
+  return { validated: "default" };
+};
+
+const FormGroupCustom = ({
+  className,
+  label,
+  labelIcon,
+  isRequired,
+  helperText,
+  meta,
+  validateOnMount,
+  description,
+  hideLabel,
+  children,
+  id,
+  FormGroupProps,
+}) => (
+  <Pf4FormGroup
+    className={className}
+    isRequired={isRequired}
+    label={!hideLabel && label}
+    labelIcon={!hideLabel && labelIcon}
+    fieldId={id}
+    helperText={((meta.touched || validateOnMount) && meta.warning) || helperText}
+    helperTextInvalid={meta.error || meta.submitError}
+    {...showError(meta, validateOnMount)}
+    {...FormGroupProps}
+  >
+    {description && (
+      <TextContent>
+        <Text component="small">{description}</Text>
+      </TextContent>
+    )}
+    {children}
+  </Pf4FormGroup>
+);
+
+FormGroupCustom.propTypes = {
+  className: PropTypes.string,
+  label: PropTypes.node,
+  labelIcon: PropTypes.node,
+  isRequired: PropTypes.bool,
+  helperText: PropTypes.node,
+  meta: PropTypes.object.isRequired,
+  description: PropTypes.node,
+  hideLabel: PropTypes.bool,
+  validateOnMount: PropTypes.bool,
+  id: PropTypes.string.isRequired,
+  children: PropTypes.oneOfType([PropTypes.element, PropTypes.arrayOf(PropTypes.element)]).isRequired,
+  FormGroupProps: PropTypes.object,
+};
+
+export default FormGroupCustom;

--- a/components/Wizard/formComponents/TextFieldCustom.js
+++ b/components/Wizard/formComponents/TextFieldCustom.js
@@ -1,14 +1,17 @@
 import React from "react";
-import { FormGroup, TextInput } from "@patternfly/react-core";
+import { TextInput } from "@patternfly/react-core";
 import PropTypes from "prop-types";
 
 import { useFieldApi } from "@data-driven-forms/react-form-renderer";
 import showError from "@data-driven-forms/pf4-component-mapper/show-error/show-error";
+import FormGroupCustom from "./FormGroupCustom";
 
 const TextFieldCustom = (props) => {
   const {
+    className,
     label,
     labelIcon,
+    hideLabel,
     isRequired,
     helperText,
     meta,
@@ -22,15 +25,19 @@ const TextFieldCustom = (props) => {
     ...rest
   } = useFieldApi(props);
   return (
-    <FormGroup
+    <FormGroupCustom
+      className={className}
       label={label}
       labelIcon={labelIcon}
+      hideLabel={hideLabel}
       isRequired={isRequired}
       helperText={helperText}
       description={description}
+      meta={meta}
+      validateOnMount={validateOnMount}
       id={id || input.name}
       {...showError(meta, validateOnMount)}
-      {...FormGroupProps}
+      FormGroupProps={FormGroupProps}
     >
       <TextInput
         {...input}
@@ -41,7 +48,7 @@ const TextFieldCustom = (props) => {
         isReadOnly={isReadOnly}
         isDisabled={isDisabled}
       />
-    </FormGroup>
+    </FormGroupCustom>
   );
 };
 

--- a/components/Wizard/steps/details.js
+++ b/components/Wizard/steps/details.js
@@ -34,10 +34,12 @@ export default {
       initialValue: 6,
       isRequired: true,
       autoFocus: true,
-      condition: {
-        when: "image-output-type",
-        is: "ami",
-      },
+      condition: [
+        {
+          when: "image-output-type",
+          is: "ami",
+        },
+      ],
       validate: [
         {
           type: validatorTypes.REQUIRED,
@@ -77,7 +79,17 @@ export default {
       isRequired: true,
       autoFocus: true,
       condition: {
-        not: [{ when: "image-output-type", is: "ami" }],
+        when: "image-output-type",
+        is: [
+          "ami",
+          "edge-simplified-installer",
+          "fedora-iot-commit",
+          "edge-commit",
+          "edge-container",
+          "edge-installer",
+          "image-installer",
+        ],
+        notMatch: true,
       },
       validate: [
         {
@@ -88,6 +100,50 @@ export default {
           includeThreshold: true,
           value: 2,
           message: "Minimum image size is 2GB",
+        },
+      ],
+    },
+    {
+      component: "text-field-custom",
+      name: "image-size",
+      className: "pf-u-w-50",
+      type: "number",
+      label: "Image size",
+      labelIcon: (
+        <Popover
+          bodyContent={
+            <>
+              Set the size that you want the image to be when instantiated. The total package size and target
+              destination of your image should be considered when setting the image size.
+            </>
+          }
+          aria-label="Image size help"
+        >
+          <Button variant="plain" aria-label="Image size help">
+            <HelpIcon />
+          </Button>
+        </Popover>
+      ),
+      helperText: "Minimum image size is 10GB",
+      initializeOnMount: true,
+      initialValue: 10,
+      isRequired: true,
+      autoFocus: true,
+      condition: [
+        {
+          when: "image-output-type",
+          is: "edge-simplified-installer",
+        },
+      ],
+      validate: [
+        {
+          type: validatorTypes.REQUIRED,
+        },
+        {
+          type: validatorTypes.MIN_NUMBER_VALUE,
+          includeThreshold: true,
+          value: 10,
+          message: "Minimum image size is 10GB",
         },
       ],
     },

--- a/components/Wizard/steps/imageOutputStepMapper.js
+++ b/components/Wizard/steps/imageOutputStepMapper.js
@@ -12,6 +12,18 @@ export default (props) => {
       default:
         return "details";
     }
+    // check if image type is an ostree-settings
+  } else if (
+    [
+      "fedora-iot-commit",
+      "edge-commit",
+      "edge-container",
+      "edge-installer",
+      "edge-raw-image",
+      "edge-simplified-installer",
+    ].includes(props["image-output-type"])
+  ) {
+    return "ostree-settings";
   } else {
     return "details";
   }

--- a/components/Wizard/steps/index.js
+++ b/components/Wizard/steps/index.js
@@ -7,5 +7,6 @@ export { default as ociAuth } from "./ociAuth";
 export { default as ociDest } from "./ociDest";
 export { default as vmwareAuth } from "./vmwareAuth";
 export { default as vmwareDest } from "./vmwareDest";
+export { default as ostreeSettings } from "./ostreeSettings";
 export { default as details } from "./details";
 export { default as review } from "./review";

--- a/components/Wizard/steps/ostreeSettings.js
+++ b/components/Wizard/steps/ostreeSettings.js
@@ -1,0 +1,123 @@
+import React from "react";
+import validatorTypes from "@data-driven-forms/react-form-renderer/validator-types";
+import { Popover, Button } from "@patternfly/react-core";
+import { HelpIcon } from "@patternfly/react-icons";
+
+export default {
+  title: "OSTree Settings",
+  name: "ostree-settings",
+  nextStep: "details",
+  fields: [
+    {
+      component: "text-field-custom",
+      name: "ostree-repo-url",
+      className: "pf-u-w-75",
+      label: "Repository URL",
+      labelIcon: (
+        <Popover
+          bodyContent={
+            <>
+              Provide the URL of the upstream repository. This repository is where the parent OSTree commit will be
+              pulled from.
+            </>
+          }
+          aria-label="Repository URL help"
+        >
+          <Button variant="plain" aria-label="Repository URL help">
+            <HelpIcon />
+          </Button>
+        </Popover>
+      ),
+      condition: {
+        when: "image-output-type",
+        is: [
+          "fedora-iot-commit",
+          "edge-commit",
+          "edge-container",
+          "edge-installer",
+          "edge-raw-image",
+          "edge-simplified-installer",
+        ],
+      },
+      validate: [{ type: "ostreeValidator" }],
+      // eslint-disable-next-line no-unused-vars
+      resolveProps: (props, { meta, input }, formOptions) => {
+        if (formOptions.getState().values["image-output-type"] === "edge-raw-image") {
+          return {
+            isRequired: true,
+            validate: [
+              {
+                type: validatorTypes.REQUIRED,
+              },
+            ],
+          };
+        }
+      },
+    },
+    {
+      component: "text-field-custom",
+      name: "ostree-parent-commit",
+      className: "pf-u-w-75",
+      label: "Parent commit",
+      labelIcon: (
+        <Popover
+          bodyContent={
+            <>
+              Provide the ID of the latest commit in the updates repository for which this commit provides an update. If
+              no commit is specified it will be inferred from the parent repository.{" "}
+            </>
+          }
+          aria-label="Parent commit help"
+        >
+          <Button variant="plain" aria-label="Parent commit help">
+            <HelpIcon />
+          </Button>
+        </Popover>
+      ),
+      condition: {
+        when: "image-output-type",
+        is: ["fedora-iot-commit", "edge-commit", "edge-container"],
+      },
+      validate: [{ type: "ostreeValidator" }],
+    },
+    {
+      component: "text-field-custom",
+      name: "ostree-ref",
+      className: "pf-u-w-75",
+      label: "Ref",
+      labelIcon: (
+        <Popover
+          bodyContent={
+            <>Provide the name of the branch for the content. If the ref does not already exist it will be created.</>
+          }
+          aria-label="Ref help"
+        >
+          <Button variant="plain" aria-label="Ref help">
+            <HelpIcon />
+          </Button>
+        </Popover>
+      ),
+      helperText:
+        "Valid characters for ref are letters from a to z, the digits from 0 to 9, the hyphen (-), the underscore (_), the period (.), and the forward slash (/). A ref must start with a letter, a number, or an underscore. Slashes must also be followed by a letter or number.",
+      condition: {
+        when: "image-output-type",
+        is: [
+          "fedora-iot-commit",
+          "edge-commit",
+          "edge-container",
+          "edge-installer",
+          "edge-raw-image",
+          "edge-simplified-installer",
+        ],
+      },
+      validate: [
+        {
+          type: validatorTypes.PATTERN,
+          pattern: /^(?:[\w\d][-._\w\d]*\/)*[\w\d][-._\w\d]*$/i,
+          message:
+            "Valid characters for ref are letters from a to z, the digits from 0 to 9, the hyphen (-), the underscore (_), the period (.), and the forward slash (/). A ref must start with a letter, a number, or an underscore. Slashes must also be followed by a letter or number.",
+        },
+      ],
+    },
+  ],
+};

--- a/components/Wizard/validators/index.js
+++ b/components/Wizard/validators/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export { default as ostreeValidator } from "./ostreeValidator";

--- a/components/Wizard/validators/ostreeValidator.js
+++ b/components/Wizard/validators/ostreeValidator.js
@@ -1,0 +1,11 @@
+const OSTreeValidator = () => (value, formValues) => {
+  if (!value) {
+    return undefined;
+  }
+
+  if (formValues["ostree-repo-url"]?.length > 0 && formValues["ostree-parent-commit"]?.length > 0) {
+    return "Either the parent commit or repository url can be specified. Not both.";
+  }
+};
+
+export default OSTreeValidator;

--- a/core/sagas/composes.js
+++ b/core/sagas/composes.js
@@ -148,7 +148,7 @@ function* fetchComposeTypes() {
       "edge-installer": "RHEL for Edge Installer (.iso)",
       "edge-raw-image": "RHEL for Edge Raw Image (.raw.xz)",
       "image-installer": "RHEL Installer (.iso)",
-      "edge-simplified-installer": "RHEL for Edge Simplified Installer (.iso)",
+      // "edge-simplified-installer": "RHEL for Edge Simplified Installer (.iso)",
       vhd: "Microsoft Azure (.vhd)",
       vmdk: "VMWare VSphere (.vmdk)",
     };


### PR DESCRIPTION
This PR is a MVP. For some image types the details page will be empty but instead of changing the routing I am leaving it empty since soon other blueprint customization will be added to the wizard and the routing would need to be changed back.

Also see issue https://github.com/osbuild/cockpit-composer/issues/1465