### PR TITLE
Toolbar: fix blueprint search

### DIFF
--- a/components/Modal/ManageSources.js
+++ b/components/Modal/ManageSources.js
@@ -5,7 +5,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { FormattedMessage, defineMessages, injectIntl } from "react-intl";
-import { Alert, Spinner, Modal, ModalVariant, Title } from "@patternfly/react-core";
+import { Alert, Button, Spinner, Modal, ModalVariant, Title } from "@patternfly/react-core";
 import SourcesListItem from "../ListView/SourcesListItem";
 import EmptyState from "../EmptyState/EmptyState";
 import {
@@ -98,12 +98,12 @@ class ManageSources extends React.Component {
   render() {
     return (
       <>
-        <a href="#" onClick={!this.props.disabled ? this.open : undefined}>
+        <Button variant="secondary" onClick={this.open}>
           <FormattedMessage
             defaultMessage="Manage sources"
             description="User action for displaying the list of source repositories"
           />
-        </a>
+        </Button>
         {this.state.showModal && (
           <ManageSourcesModal
             manageSources={this.props.manageSources}
@@ -464,7 +464,6 @@ ManageSources.propTypes = {
     sources: PropTypes.objectOf(PropTypes.object),
     error: PropTypes.object,
   }),
-  disabled: PropTypes.bool,
   removeModalManageSourcesEntry: PropTypes.func,
   addModalManageSourcesEntry: PropTypes.func,
   modalManageSourcesFailure: PropTypes.func,
@@ -473,7 +472,6 @@ ManageSources.propTypes = {
 
 ManageSources.defaultProps = {
   manageSources: {},
-  disabled: false,
   removeModalManageSourcesEntry() {},
   addModalManageSourcesEntry() {},
   modalManageSourcesFailure() {},

--- a/components/Toolbar/BlueprintsToolbar.js
+++ b/components/Toolbar/BlueprintsToolbar.js
@@ -1,79 +1,77 @@
-import React from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
-import ToolbarLayout from "./ToolbarLayout";
+import { Toolbar, ToolbarItem, ToolbarContent, ToolbarGroup, Button, SearchInput } from "@patternfly/react-core";
+import { SortAlphaDownIcon, SortAlphaDownAltIcon } from "@patternfly/react-icons";
+
 import CreateBlueprint from "../Modal/CreateBlueprint";
 import ManageSources from "../Modal/ManageSources";
 
-const BlueprintsToolbar = (props) => (
-  <ToolbarLayout>
-    <div className="form-group">
-      {(props.sortKey === "name" && props.sortValue === "DESC" && (
-        <button
-          className="btn btn-link"
-          type="button"
-          disabled={props.emptyState}
-          onClick={() => props.sortSetValue("ASC")}
-        >
-          <span className="fa fa-sort-alpha-asc" />
-        </button>
-      )) ||
-        (props.sortKey === "name" && props.sortValue === "ASC" && (
-          <button
-            className="btn btn-link"
-            type="button"
-            disabled={props.emptyState}
-            onClick={() => props.sortSetValue("DESC")}
-          >
-            <span className="fa fa-sort-alpha-desc" />
-          </button>
-        ))}
-    </div>
-    <div className="toolbar-pf-action-right">
-      <div className="form-group">
-        <CreateBlueprint blueprintNames={props.blueprintNames} disabled={props.errorState} />
-        <div className="dropdown btn-group dropdown-kebab-pf">
-          <button
-            className="btn btn-link dropdown-toggle"
-            type="button"
-            id="dropdownKebab"
-            data-toggle="dropdown"
-            aria-haspopup="true"
-            aria-expanded="false"
-          >
-            <span className="fa fa-ellipsis-v" />
-          </button>
-          <ul className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownKebab">
-            <li className={props.errorState ? "disabled" : ""}>
-              <ManageSources manageSources={props.manageSources} disabled={props.errorState} />
-            </li>
-          </ul>
-        </div>
-      </div>
-    </div>
-  </ToolbarLayout>
-);
+const BlueprintsToolbar = (props) => {
+  const [inputValue, setInputValue] = useState("");
+
+  const onInputChange = (newValue) => {
+    setInputValue(newValue);
+
+    const filter = {
+      key: "name",
+      value: newValue,
+    };
+    props.filterAddValue(filter);
+  };
+
+  const toolbarItems = (
+    <>
+      <ToolbarGroup alignment={{ default: "alignLeft" }}>
+        <ToolbarItem variant="search-filter">
+          <SearchInput
+            aria-label="blueprints search input"
+            onChange={onInputChange}
+            value={inputValue}
+            onClear={() => onInputChange("")}
+          />
+        </ToolbarItem>
+        <ToolbarItem variant="icon-button-group">
+          {(props.sortValue === "DESC" && (
+            <Button variant="plain" aria-label="sort asc" onClick={() => props.sortSetValue("ASC")}>
+              <SortAlphaDownIcon />
+            </Button>
+          )) ||
+            (props.sortValue === "ASC" && (
+              <Button variant="plain" aria-label="sort desc" onClick={() => props.sortSetValue("DESC")}>
+                <SortAlphaDownAltIcon />
+              </Button>
+            ))}
+        </ToolbarItem>
+      </ToolbarGroup>
+      <ToolbarGroup variant="button-group" alignment={{ default: "alignRight" }}>
+        <ToolbarItem>
+          <CreateBlueprint blueprintNames={props.blueprintNames} disabled={props.errorState} />
+        </ToolbarItem>
+        <ToolbarItem>
+          <ManageSources manageSources={props.manageSources} disabled={props.errorState} />
+        </ToolbarItem>
+      </ToolbarGroup>
+    </>
+  );
+
+  return (
+    <Toolbar>
+      <ToolbarContent>{toolbarItems}</ToolbarContent>
+    </Toolbar>
+  );
+};
 
 BlueprintsToolbar.propTypes = {
   blueprintNames: PropTypes.arrayOf(PropTypes.string).isRequired,
   sortSetValue: PropTypes.func,
   errorState: PropTypes.bool,
-  emptyState: PropTypes.bool,
-  sortKey: PropTypes.string,
   sortValue: PropTypes.string,
   manageSources: PropTypes.shape({
     fetchingSources: PropTypes.bool,
     sources: PropTypes.objectOf(PropTypes.object),
     error: PropTypes.object,
   }),
-};
-
-BlueprintsToolbar.defaultProps = {
-  sortSetValue() {},
-  errorState: false,
-  emptyState: false,
-  sortKey: "",
-  sortValue: "",
-  manageSources: {},
+  filterAddValue: PropTypes.func,
 };
 
 export default BlueprintsToolbar;

--- a/pages/blueprints/index.js
+++ b/pages/blueprints/index.js
@@ -1,8 +1,8 @@
 import React from "react";
-import { FormattedMessage, defineMessages, injectIntl } from "react-intl";
+import { defineMessages, injectIntl } from "react-intl";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { Button, EmptyStatePrimary } from "@patternfly/react-core";
+import { EmptyStatePrimary } from "@patternfly/react-core";
 import { ExclamationCircleIcon } from "@patternfly/react-icons";
 import Layout from "../../components/Layout/Layout";
 import BlueprintsDataList from "../../components/ListView/BlueprintsDataList";
@@ -126,13 +126,7 @@ class BlueprintsPage extends React.Component {
             <EmptyState
               title={formatMessage(messages.noResultsTitle)}
               message={formatMessage(messages.noResultsMessage)}
-            >
-              <EmptyStatePrimary>
-                <Button variant="link" type="button" onClick={blueprintsFilterClearValues}>
-                  <FormattedMessage defaultMessage="Clear all filters" />
-                </Button>
-              </EmptyStatePrimary>
-            </EmptyState>
+            />
           )}
       </Layout>
     );


### PR DESCRIPTION
The blueprint list can be sorted and filtered by name. Also, the Manage
sources modal is no longer hidden by a dropdown kebab.