### PR TITLE
Wizard: Packages/Review step bugfix, zero packages case

### DIFF
--- a/components/Wizard/formComponents/Packages.js
+++ b/components/Wizard/formComponents/Packages.js
@@ -53,6 +53,8 @@ const Packages = ({ defaultArch, ...props }) => {
           selectedPackages.map((pkg) => pkg.name)
         );
         setPackagesChosenSorted(selectedPackages);
+      } else {
+        change(input.name, []);
       }
       setPackagesChosenLoading(false);
     };

--- a/components/Wizard/formComponents/Review.js
+++ b/components/Wizard/formComponents/Review.js
@@ -126,17 +126,16 @@ const Review = (props) => {
           {formValues?.["image-output-type"] === "vhd" && formValues?.["image-upload"] && AzureReview(formValues)}
           {formValues?.["image-output-type"] === "vmdk" && formValues?.["image-upload"] && VMWareReview(formValues)}
           {formValues?.["image-output-type"] === "oci" && formValues?.["image-upload"] && ociReview(formValues)}
-          <TextListItem component={TextListItemVariants.dt}>Packages</TextListItem>
-          <FormSpy subscription={{ values: true }}>
-            {() => {
+          <FormSpy
+            subscription={{ values: true }}
+            onChange={() => {
               setFormValues(getState()?.values);
-              return (
-                <TextListItem component={TextListItemVariants.dd}>
-                  {formValues["selected-packages"] ? formValues["selected-packages"].length : <Spinner size="sm" />}
-                </TextListItem>
-              );
             }}
-          </FormSpy>
+          />
+          <TextListItem component={TextListItemVariants.dt}>Packages</TextListItem>
+          <TextListItem component={TextListItemVariants.dd}>
+            {formValues["selected-packages"] ? formValues["selected-packages"].length : <Spinner size="sm" />}
+          </TextListItem>
           <TextListItem component={TextListItemVariants.dt}>Dependencies</TextListItem>
           <TextListItem component={TextListItemVariants.dd}>
             {dependencies || dependencies === 0 ? dependencies : <Spinner size="sm" />}


### PR DESCRIPTION
This commit fixes a bug where if the blueprint package list was empty,
the form state was not updated to reflect this. The form state's
"selected-packages" field is now correctly set to [] if a blueprint does
not contain any packages.

This commit also modifies the Review step's state management. The
package list is stored in the form state, which complicates state
management as changes to the form state do not cause re-renders. This is
problematic because the package list is retrieved via an asynchronous
API call and it is possible to click to the review step before the
package list has loaded. In this case, we would like for the Review step
to re-render when the package list loads, but changes to the form state
do not cause re-renders as noted previously! A `<FormSpy>` component is
used to track changes to the form state and force a rerender via a
`setState()` hook. This commit changes the `<FormSpy>` - it now takes an
`onChange` prop and is only responsible for setting state, not rendering a
component. This seems to be much more robust and eliminates an error
message related to the `<FormSpy>` that we were previously experiencing.