### PR TITLE
Wizard: Fix number of dependencies shown on Review step

### DIFF
--- a/components/Wizard/formComponents/Review.js
+++ b/components/Wizard/formComponents/Review.js
@@ -99,13 +99,24 @@ const Review = (props) => {
   const [dependencies, setDependencies] = useState(undefined);
 
   useEffect(() => {
-    const fetchDependencies = async (blueprintName) => {
-      const result = await composer.depsolveBlueprint(blueprintName);
-      const numDependencies = result.blueprints[0].dependencies.length - formValues["selected-packages"].length;
-      setDependencies(numDependencies);
+    const fetchDependencies = async (packages) => {
+      if (packages?.length) {
+        const result = await composer.getComponentDependencies(packages);
+        // Build a Set() because Packages may share dependencies
+        const dependencies = new Set(
+          result.reduce((deps, pkg) => {
+            const pkgDependencies = pkg.dependencies.map((dep) => dep.name);
+            return [...deps, ...pkgDependencies];
+          }, [])
+        );
+        setDependencies(dependencies.size);
+      } else {
+        setDependencies(0);
+      }
     };
+
     if (formValues["selected-packages"]) {
-      fetchDependencies(props.blueprintName);
+      fetchDependencies(formValues["selected-packages"]);
     }
   });
 


### PR DESCRIPTION
The number of dependencies is determined by depsolving the blueprint.
The array of dependencies does not include the blueprint packages, so
the number of packages should not be subtracted from the number of
dependencies.