### PR TITLE
Wizard: Fix packages step available packages search bug

### DIFF
--- a/components/Wizard/formComponents/Packages.js
+++ b/components/Wizard/formComponents/Packages.js
@@ -384,6 +384,7 @@ const Packages = ({ defaultArch, ...props }) => {
             onSearch={handlePackagesAvailableSearch}
             resetButtonLabel="Clear available packages search"
             onClear={handleClearAvailableSearch}
+            isDisabled={packagesChosenLoading}
           />
         }
       >


### PR DESCRIPTION
Fixes #1494. Searching for available packages is now disabled while the
current packages list is loading. Packages already in the current
packages list should not appear in the available packages list.
Therefore, searching for available packages is disabled until the
current packages list has loaded and is available for comparison.