### PR TITLE
core: fix blueprintsGetAll for when there are no blueprints

### DIFF
--- a/core/actions/blueprints.js
+++ b/core/actions/blueprints.js
@@ -20,8 +20,10 @@ export const blueprintsUpdated = (blueprint) => ({
 export const blueprintsGetAll = () => async (dispatch) => {
   try {
     const bpNames = await composer.getBlueprintsNames();
-    const blueprints = await composer.getBlueprintsInfo(bpNames);
-    blueprints.forEach((bp) => dispatch(blueprintsAdded(bp)));
+    if (bpNames?.length) {
+      const blueprints = await composer.getBlueprintsInfo(bpNames);
+      blueprints.forEach((bp) => dispatch(blueprintsAdded(bp)));
+    }
     dispatch(blueprintsFetched());
   } catch (error) {
     dispatch(blueprintsFailure(error));


### PR DESCRIPTION
The blueprints/info route should not be called with an empty list of blueprint names. This will return an error which will cause us to load an error state instead of the No blueprints state.