### PR TITLE
ostree: fix ostree customizations

### DIFF
--- a/components/Wizard/steps/ostreeSettings.js
+++ b/components/Wizard/steps/ostreeSettings.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 import React from "react";
 import { useIntl, defineMessages, FormattedMessage } from "react-intl";
 import validatorTypes from "@data-driven-forms/react-form-renderer/validator-types";
@@ -19,17 +20,17 @@ const messages = defineMessages({
   parentCommitPopoverBody: {
     id: "wizard.ostree.parentCommit.popoverBody",
     defaultMessage:
-      "Provide the ID of the latest commit in the updates repository for which this commit provides an update. " +
-      "If no commit is specified it will be inferred from the parent repository.",
+      "Provide the commit id or ref of the parent in the repository for which this commit provides an update. " +
+      "If no parent is specified it will be inferred from the user-defined ref.",
   },
   parentCommitPopoverAria: {
     id: "wizard.ostree.parentCommit.popoverAria",
-    defaultMessage: "Parent commit help",
+    defaultMessage: "Parent help",
   },
   refPopoverBody: {
     id: "wizard.ostree.ref.popoverBody",
     defaultMessage:
-      "Provide the name of the branch for the content. If the ref does not already exist it will be created.",
+      "Provide the name of the branch for the content. If the ref does not already exist it will be created. If the ref is not specified, the default ref for the distro will be used.",
   },
   refPopoverAria: {
     id: "wizard.ostree.ref.popoverAria",
@@ -66,15 +67,38 @@ const ostreeSettings = () => {
         ),
         condition: {
           when: "image-output-type",
-          is: ["fedora-iot-commit", "edge-commit", "edge-container", "edge-installer", "edge-simplified-installer"],
+          is: [
+            "fedora-iot-commit",
+            "edge-commit",
+            "edge-container",
+            "edge-raw-image",
+            "edge-installer",
+            "edge-simplified-installer",
+          ],
         },
-        validate: [{ type: "ostreeValidator" }],
+        resolveProps: (props, { meta, input }, formOptions) => {
+          const imageType = formOptions.getState().values["image-output-type"];
+          if (
+            imageType === "edge-raw-image" ||
+            imageType === "edge-installer" ||
+            imageType === "edge-simplified-installer"
+          ) {
+            return {
+              isRequired: true,
+              validate: [
+                {
+                  type: validatorTypes.REQUIRED,
+                },
+              ],
+            };
+          }
+        },
       },
       {
         component: "text-field-custom",
         name: "ostree-parent-commit",
         className: "pf-u-w-75",
-        label: <FormattedMessage id="wizard.ostree.parentCommit.label" defaultMessage="Parent commit" />,
+        label: <FormattedMessage id="wizard.ostree.parentCommit.label" defaultMessage="Parent" />,
         labelIcon: (
           <Popover
             bodyContent={intl.formatMessage(messages.parentCommitPopoverBody)}
@@ -87,21 +111,7 @@ const ostreeSettings = () => {
         ),
         condition: {
           when: "image-output-type",
-          is: ["fedora-iot-commit", "edge-commit", "edge-container", "edge-raw-image"],
-        },
-        validate: [{ type: "ostreeValidator" }],
-        // eslint-disable-next-line no-unused-vars
-        resolveProps: (props, { meta, input }, formOptions) => {
-          if (formOptions.getState().values["image-output-type"] === "edge-raw-image") {
-            return {
-              isRequired: true,
-              validate: [
-                {
-                  type: validatorTypes.REQUIRED,
-                },
-              ],
-            };
-          }
+          is: ["fedora-iot-commit", "edge-commit", "edge-container"],
         },
       },
       {

--- a/test/verify/check-wizard
+++ b/test/verify/check-wizard
@@ -533,16 +533,13 @@ class TestWizard(composerlib.ComposerCase):
         b.focus("input[id='ostree-repo-url']")
         b.key_press("127.0. 0.1")
 
-        b.wait_visible("label:contains('Parent commit')")
-        b.click("button[aria-label='Parent commit help']")
+        b.wait_visible("label:contains('Parent')")
+        b.click("button[aria-label='Parent help']")
         # b.wait_text(".pf-c-popover__body",
         #             "Provide the name of the branch for the content. If the ref does not already exist it will be created.")        b.click(".pf-c-popover__content button[aria-label='Close']")
         b.click(".pf-c-popover__content button[aria-label='Close']")
         b.wait_not_present(".pf-c-popover__body")
         b.set_input_text("input[id='ostree-parent-commit']", "asdf1234")
-        # only url or commit can be specified
-        b.wait_attr("button:contains('Next')", "disabled", "")
-        b.set_input_text("input[id='ostree-parent-commit']", "")
 
         b.wait_visible("label:contains('Ref')")
         b.click("button[aria-label='Ref help']")


### PR DESCRIPTION
The Parent commit is now Parent since it can be either a commit id or
ref. The help text is updated. The parent is required for raw-image,
installer, and simplified-installer. The parent is only available for
commit and container.