### PR TITLE
Bump cockpit test lib to 278

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ machine: bots
 
 # checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
 test/common:
-	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 272
+	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 278
 	git checkout --force FETCH_HEAD -- test/common
 	git reset test/common
 


### PR DESCRIPTION
This brings compatibility with Python 3.11:
https://github.com/cockpit-project/cockpit/commit/4ac3051d86d

The CI tasks container is Fedora 37 now, which has that Python version.

----

Blocks https://github.com/cockpit-project/bots/pull/4002