### PR TITLE
Modal: add ExportBlueprint modal

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -111,6 +111,22 @@ export const getBlueprintsInfo = (blueprintNames) => {
   ).then((response) => response.blueprints);
 };
 
+export const getBlueprintJSON = async (blueprintName) => {
+  const response = await get(
+    `/api/v0/blueprints/info/${encodeURIComponent(blueprintName)}`
+  );
+  return response.blueprints[0];
+};
+
+export const getBlueprintTOML = async (blueprintName) => {
+  const path = `/api/v0/blueprints/info/${encodeURIComponent(
+    blueprintName
+  )}?format=toml`;
+
+  const toml = await get(path, { replyFormat: "raw" });
+  return toml;
+};
+
 export function depsolveBlueprint(blueprintName) {
   return get(
     `/api/v0/blueprints/depsolve/${encodeURIComponent(blueprintName)}`

--- a/src/components/Modal/ExportBlueprint.css
+++ b/src/components/Modal/ExportBlueprint.css
@@ -1,0 +1,11 @@
+.pf-c-code-block {
+    overflow: auto;
+}
+
+.codeblock-toolbar {
+    background-color: var(--pf-global--BackgroundColor--200);
+}
+
+.codeblock-toolbar .pf-c-button {
+    background-color: transparent;
+}

--- a/src/components/Modal/ExportBlueprint.js
+++ b/src/components/Modal/ExportBlueprint.js
@@ -1,0 +1,118 @@
+import React, { useEffect } from "react";
+import PropTypes from "prop-types";
+import { useIntl, FormattedMessage } from "react-intl";
+import {
+  CodeBlock,
+  CodeBlockCode,
+  Modal,
+  ModalVariant,
+  Button,
+  Select,
+  SelectOption,
+} from "@patternfly/react-core";
+import { CopyIcon, DownloadIcon } from "@patternfly/react-icons";
+
+import { getBlueprintTOML, getBlueprintJSON } from "../../api";
+import "./ExportBlueprint.css";
+
+export const ExportBlueprint = (props) => {
+  const intl = useIntl();
+
+  const [isModalOpen, setIsModalOpen] = React.useState(false);
+  const [isSelectOpen, setIsSelectOpen] = React.useState(false);
+  const [selected, setSelected] = React.useState("TOML");
+  const [codeJSON, setCodeJSON] = React.useState("");
+  const [codeTOML, setCodeTOML] = React.useState("");
+
+  useEffect(() => {
+    getCode();
+  }, []);
+
+  const getCode = async () => {
+    const jsonObject = await getBlueprintJSON(props.blueprint.name);
+    const json = JSON.stringify(jsonObject, null, 2);
+    const toml = await getBlueprintTOML(props.blueprint.name);
+    setCodeTOML(toml);
+    setCodeJSON(json);
+  };
+
+  const handleModalToggle = () => {
+    setIsModalOpen(!isModalOpen);
+  };
+
+  const handleSelectToggle = () => {
+    setIsSelectOpen(!isSelectOpen);
+  };
+
+  const onSelect = (e, selection) => {
+    setIsSelectOpen(false);
+    setSelected(selection);
+  };
+
+  const handleCopy = () => {
+    const code = selected === "TOML" ? codeTOML : codeJSON;
+    navigator.clipboard.writeText(code);
+  };
+
+  const handleDownload = () => {
+    const code = selected === "TOML" ? codeTOML : codeJSON;
+    const filename = `${props.blueprint.name}.${selected.toLowerCase()}`;
+
+    const link = document.createElement("a");
+    link.href = "data:text/plain;charset=utf-8," + encodeURIComponent(code);
+    link.download = filename;
+
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
+  return (
+    <>
+      <Button variant="secondary" onClick={handleModalToggle}>
+        <FormattedMessage defaultMessage="Export blueprint" />
+      </Button>
+      <Modal
+        variant={ModalVariant.medium}
+        title={intl.formatMessage({
+          defaultMessage: "Export blueprint",
+        })}
+        id="modal-export-blueprint"
+        isSelectOpen={isModalOpen}
+        onClose={handleModalToggle}
+      >
+        <div className="pf-u-display-flex pf-u-justify-content-space-between codeblock-toolbar">
+          <Select
+            onSelect={onSelect}
+            handleSelectToggle={handleSelectToggle}
+            isSelectOpen={isSelectOpen}
+            selections={selected}
+            width="25%"
+          >
+            <SelectOption key="json" value="JSON" />
+            <SelectOption key="toml" value="TOML" />
+          </Select>
+          <div>
+            <Button variant="plain" onClick={handleCopy}>
+              <CopyIcon />
+            </Button>
+            <Button variant="plain" onClick={handleDownload}>
+              <DownloadIcon />
+            </Button>
+          </div>
+        </div>
+        <CodeBlock className="pf-u-h-50vh">
+          <CodeBlockCode className="pf-u-h-50vh">
+            {selected === "JSON" ? codeJSON : codeTOML}
+          </CodeBlockCode>
+        </CodeBlock>
+      </Modal>
+    </>
+  );
+};
+
+ExportBlueprint.propTypes = {
+  blueprint: PropTypes.object,
+};
+
+export default ExportBlueprint;

--- a/src/components/Table/BlueprintTable.js
+++ b/src/components/Table/BlueprintTable.js
@@ -5,9 +5,11 @@ import { useIntl } from "react-intl";
 import { TableComposable, Tr, Tbody, Td } from "@patternfly/react-table";
 import CreateImageWizard from "../Wizard/CreateImageWizard";
 import DeleteBlueprint from "../Modal/DeleteBlueprint";
+import ExportBlueprint from "../Modal/ExportBlueprint";
 
 const BlueprintTable = (props) => {
   const intl = useIntl();
+
   return (
     <TableComposable
       aria-label={intl.formatMessage({ defaultMessage: "Blueprints table" })}
@@ -20,6 +22,9 @@ const BlueprintTable = (props) => {
             </Td>
             <Td modifier="fitContent">
               <CreateImageWizard blueprint={blueprint} />
+            </Td>
+            <Td modifier="fitContent">
+              <ExportBlueprint blueprint={blueprint} />
             </Td>
             <Td modifier="fitContent">
               <DeleteBlueprint blueprint={blueprint} />

--- a/translations/en.json
+++ b/translations/en.json
@@ -8,6 +8,7 @@
   "7pIRny": "DIUN public key insecure",
   "8lgG7e": "DIUN public key hash",
   "9llaed": "Download logs",
+  "9zOqa2": "Export blueprint",
   "AZSxPR": "Packages",
   "DWC301": "Are you sure you want to delete the image?",
   "E8zzIG": "Release",


### PR DESCRIPTION
Blueprints can be exported as either TOML or JSON. 
This export function allows copying to clipboard or downloading a file.

![Screenshot from 2022-11-30 17-43-06](https://user-images.githubusercontent.com/11712857/204857392-d98bf172-7a27-42cf-8649-a86bfb0e9a93.png)

