### PR TITLE
CreateImageWizard: fix the key of oci's private key

### DIFF
--- a/src/components/Wizard/CreateImageWizard.js
+++ b/src/components/Wizard/CreateImageWizard.js
@@ -132,7 +132,7 @@ const CreateImageWizard = (props) => {
           provider: "oci",
           settings: {
             user: formValues.image.upload.settings.user,
-            privateKey: formValues.image.upload.settings.privateKey,
+            private_key: formValues.image.upload.settings.privateKey,
             fingerprint: formValues.image.upload.settings.fingerprint,
             filename: formValues.image.upload.settings.filename,
             bucket: formValues.image.upload.settings.bucket,


### PR DESCRIPTION
The actual key for the private key is in fact `private_key`, see the API in osbuild-composer:

https://github.com/osbuild/osbuild-composer/blob/8d0f2d7e799a3449b2d7080d9a1926a0546c66f9/internal/weldr/upload.go#L93

I tested this manually, and it indeed fixes the OCI upload (currently, osbuild-composer fails because it doesn't get the private key).