### PR TITLE
Modal: Add a space to the "Delete image" prompt

### DIFF
--- a/src/components/Modal/DeleteImage.js
+++ b/src/components/Modal/DeleteImage.js
@@ -43,7 +43,7 @@ export const DeleteImage = (props) => {
           </Button>,
         ]}
       >
-        <FormattedMessage defaultMessage="Are you sure you want to delete the image?" />
+        <FormattedMessage defaultMessage="Are you sure you want to delete the image?" />{" "}
         <FormattedMessage defaultMessage="This action cannot be undone." />
       </Modal>
     </>


### PR DESCRIPTION
Fixes #1695.

This adds space after the sentence "Are you sure you want to delete the image?" in the "Delete image" prompt.