### PR TITLE
steps: Add validation to the username input

### DIFF
--- a/src/forms/steps/users.js
+++ b/src/forms/steps/users.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { defineMessages, FormattedMessage } from "react-intl";
+import { validatorTypes } from "@data-driven-forms/react-form-renderer";
 
 const messages = defineMessages({
   customizationsStepTitle: {
@@ -13,6 +14,12 @@ const messages = defineMessages({
   },
   buttonsRemoveAll: {
     defaultMessage: "Remove all users",
+  },
+  inputUsername: {
+    defaultMessage:
+      "Please enter a valid username. Your username can begin with a lower \
+      case letter or an underscore, and can only contain lower case letters, \
+      digits, underscores, or dashes",
   },
 });
 
@@ -43,6 +50,11 @@ const users = (intl) => {
             validate: [
               {
                 type: "required",
+              },
+              {
+                type: validatorTypes.PATTERN,
+                pattern: "^[a-z_][a-z0-9_-]*$",
+                message: intl.formatMessage(messages.inputUsername),
               },
             ],
           },

--- a/translations/en.json
+++ b/translations/en.json
@@ -24,6 +24,7 @@
   "5j2nFA": "Remove all zones",
   "5sg7KC": "Password",
   "7Cdpiv": "SSH Keys",
+  "7Cs5oS": "Please enter a valid username. Your username can begin with a lower case letter or an underscore, and can only contain lower case letters, digits, underscores, or dashes",
   "7CypF6": "Drag and drop a file or upload one",
   "7gA0nP": "FIDO Device Onboard",
   "7nUCu9": "Timezone",


### PR DESCRIPTION
Fixes #1706.

This adds validation to the username input. The pattern is consistent with `man` page of `useradd`. The username can begin with a lower case letter or an underscore, and can only contain lower case letters, digits, underscores, or dashes.