### PR TITLE
Modal: Increase height of the blueprint modal

### DIFF
--- a/src/components/Modal/ImportBlueprint.css
+++ b/src/components/Modal/ImportBlueprint.css
@@ -1,0 +1,3 @@
+.pf-c-file-upload__file-details {
+  min-height: 30rem;
+}

--- a/src/components/Modal/ImportBlueprint.js
+++ b/src/components/Modal/ImportBlueprint.js
@@ -13,6 +13,8 @@ import {
   createBlueprintTOML,
 } from "../../slices/blueprintsSlice";
 
+import "./ImportBlueprint.css";
+
 export const ImportBlueprint = () => {
   const dispatch = useDispatch();
   const intl = useIntl();


### PR DESCRIPTION
Fixes #1684.

This adds `ImportBlueprint.css` to increase the height of the modal with the file upload.