### PR TITLE
steps: Change text field to text area on the `SSH keys` step

### DIFF
--- a/src/forms/schemas/sshkeys.js
+++ b/src/forms/schemas/sshkeys.js
@@ -13,12 +13,17 @@ const sshkeys = {
       },
       fields: [
         {
-          component: "text-field-custom",
+          component: "textarea",
           name: "key",
-          className: "pf-u-w-50",
+          className: "pf-u-w-50 pf-u-h-25vh",
           type: "text",
           label: <FormattedMessage defaultMessage="Key" />,
           autoFocus: true,
+          validate: [
+            {
+              type: "required",
+            },
+          ],
         },
         {
           component: "text-field-custom",

--- a/test/verify/check-blueprintWizard
+++ b/test/verify/check-blueprintWizard
@@ -67,7 +67,7 @@ class TestBlueprintWizard(composerlib.ComposerCase):
 
         # sshkyes is just like users but has key and user instead
         b.click("button:contains('Add key')")
-        b.set_input_text("input[id='customizations.sshkey[0].key']", "ssh-rsa key")
+        b.set_input_text("textarea[id='customizations.sshkey[0].key']", "ssh-rsa key")
         b.set_input_text("input[id='customizations.sshkey[0].user']", "admin")
         b.click("button:contains('Next')")
 


### PR DESCRIPTION
Fixes #1709.

This changes the text field on the `SSH keys` step to text area and sets the SSH key as a required information for adding a key.