### PR TITLE
Table: Fix crashing of the blueprint table when creating a new image

### DIFF
--- a/src/components/Table/BlueprintTable.js
+++ b/src/components/Table/BlueprintTable.js
@@ -25,7 +25,7 @@ const getLatestCreationDate = (images, blueprint) => {
   );
   if (imagesByBlueprint.length > 0) {
     const latestTimestamp = Math.max(
-      ...imagesByBlueprint.map((image) => image.job_finished)
+      ...imagesByBlueprint.map((image) => image.job_created)
     );
     return formTimestampLabel(latestTimestamp);
   } else {


### PR DESCRIPTION
This fixes a bug when the blueprint table crashed after creating a new image. The date of the last creation of the image was previously based on a `job_finished` value which was undefined for images that were still building. Now it's based on a value of `job_created`.