### PR TITLE
Makefile: allow testing with the Python bridge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,27 @@ rpm: dist-gzip
 	find $(CURDIR)/output -name '*.rpm' -printf '%f\n' -exec mv {} . \;
 	rm -r "$(CURDIR)/rpmbuild"
 
-vm: rpm bots
+ifeq ("$(TEST_SCENARIO)","pybridge")
+COCKPIT_PYBRIDGE_REF = main
+COCKPIT_WHEEL = cockpit-0-py3-none-any.whl
+
+$(COCKPIT_WHEEL):
+	# aka: pip wheel git+https://github.com/cockpit-project/cockpit.git@${COCKPIT_PYBRIDGE_REF}
+	rm -rf tmp/pybridge
+	git init tmp/pybridge
+	git -C tmp/pybridge remote add origin https://github.com/cockpit-project/cockpit
+	git -C tmp/pybridge fetch --depth=1 origin ${COCKPIT_PYBRIDGE_REF}
+	git -C tmp/pybridge reset --hard FETCH_HEAD
+	cp "$$(tmp/pybridge/tools/make-wheel)" $@
+
+VM_DEPENDS = $(COCKPIT_WHEEL)
+VM_CUSTOMIZE_FLAGS = --install $(COCKPIT_WHEEL)
+endif
+
+vm: rpm bots $(VM_DEPENDS)
 	rm -f $(VM_IMAGE) $(VM_IMAGE).qcow2
 	bots/image-customize -v \
+		$(VM_CUSTOMIZE_FLAGS) \
 		--resize 20G \
 		-i `pwd`/cockpit-composer-*.noarch.rpm \
 		-i composer-cli \

--- a/test/run
+++ b/test/run
@@ -2,9 +2,8 @@
 # This is the expected entry point for Cockpit CI; will be called without
 # arguments but with an appropriate $TEST_OS, and optionally $TEST_SCENARIO
 
-if [ -n "${TEST_SCENARIO}" ]; then
-    export TEST_BROWSER="$TEST_SCENARIO"
-fi
+TEST_SCENARIO="${TEST_SCENARIO:-}"
+[ "${TEST_SCENARIO}" = "${TEST_SCENARIO##firefox}" ] || export TEST_BROWSER=firefox
 
 # overlays are too big for bot's 10GB /tmp tmpfs
 TEST_OVERLAY_DIR="$(pwd)/tmp/run"


### PR DESCRIPTION
The Python bridge is the new cockpit-bridge rewritten in Python. Before Cockpit switches it's package over we want to be able to test if all projects are supported.