### PR TITLE
Add homepage to appstream metainfo

### DIFF
--- a/public/io.weldr.cockpit-composer.metainfo.xml
+++ b/public/io.weldr.cockpit-composer.metainfo.xml
@@ -14,5 +14,6 @@
     </p>
   </description>
   <extends>org.cockpit_project.cockpit</extends>
+  <url type="homepage">https://github.com/osbuild/cockpit-composer/</url>
   <launchable type="cockpit-manifest">composer</launchable>
 </component>


### PR DESCRIPTION
Without a valid homepage `appstream-util validate` fails that the <url> tag is missing. As there is no real homepage and https://osbuild.org does not refer to Cockpit-composer I've used the Github page.

Currently Cockpit doesn't show Cockpit composer in the applications view which uses appstream information. It seems that the appstream data is not extracted? correctly. So maybe fixing this validation warning fixes it and a new build of [appstream-data](https://packages.fedoraproject.org/pkgs/appstream-data/appstream-data/) will show composer as well.