### PR TITLE
FilesystemCard: Fix typo (Fixes #1870)

### DIFF
--- a/src/components/Modal/FilesystemCard.js
+++ b/src/components/Modal/FilesystemCard.js
@@ -118,7 +118,7 @@ export const FilesystemCard = ({ blueprint }) => {
       <Modal
         variant={ModalVariant.medium}
         title={intl.formatMessage({
-          defaultMessage: "Firewall",
+          defaultMessage: "Filesystem",
         })}
         isOpen={isModalOpen}
         onClose={handleModalToggle}


### PR DESCRIPTION
There's an obvious typo in the Filesystem card title, saying 'Firewall' instead of 'Filesystem'.