### PR TITLE
Update shared cockpit files for Chromium 113 fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ machine: bots
 
 # checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
 test/common:
-	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 278
+	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 274+chromimum-sizzle
 	git checkout --force FETCH_HEAD -- test/common
 	git reset test/common
 


### PR DESCRIPTION
The most recent Chromium 113 does not work any more with sizzle, tests were hanging as soon as they switched to a frame. The latest cockpit testlib applied a workaround [1]. As the latest Cockpit library also moved to PatternFly 5, but that would be prohibitively expensive for cockpit-composer's main branch, switch to the (temporary) "274+chromium-sizzle" branch, which has that workaround backported.

Alternative approach of https://github.com/osbuild/cockpit-composer/pull/1884 so PR's can be landed at least.