### PR TITLE
ImportBlueprint: scope file preview min-height to just this component

### DIFF
--- a/src/components/Modal/ImportBlueprint.css
+++ b/src/components/Modal/ImportBlueprint.css
@@ -1,3 +1,3 @@
-.pf-c-file-upload__file-details {
+.import-blueprint-file-upload .pf-c-file-upload__file-details {
   min-height: 30rem;
 }

--- a/src/components/Modal/ImportBlueprint.js
+++ b/src/components/Modal/ImportBlueprint.js
@@ -84,6 +84,7 @@ export const ImportBlueprint = () => {
       >
         <FileUpload
           type="text"
+          className="import-blueprint-file-upload"
           value={blueprint}
           filename={filename}
           filenamePlaceholder={intl.formatMessage({


### PR DESCRIPTION
823c4f13a8fa9e6f808d82cf6e60e67d5edd55f1 introduced min-height to all file upload previews. However, we don't want to have min-height for all of them, and especially not for those that have hideDefaultPreview="true". For these, having the "global" min-height causes 30rem of empty vertical space to appear, which breaks certain stuff. An example is the UploadOCIFile component used in Oracle Cloud uploads.

Fix this by scoping the CSS rule to just the ImportBlueprint component.