### PR TITLE
Fix repo types and RHSM in sources

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -197,18 +197,18 @@ export function deleteImage(image) {
 }
 
 export function createSource(source) {
-  return post("/api/v0/projects/source/new", source);
+  return post("/api/v1/projects/source/new", source);
 }
 
 export function getAllSources() {
-  return get("/api/v0/projects/source/info/*").then(
+  return get("/api/v1/projects/source/info/*").then(
     (response) => response.sources
   );
 }
 
 export function deleteSource(sourceName) {
   return _delete(
-    `/api/v0/projects/source/delete/${encodeURIComponent(sourceName)}`
+    `/api/v1/projects/source/delete/${encodeURIComponent(sourceName)}`
   );
 }
 

--- a/src/components/Modal/SourceCardModal.js
+++ b/src/components/Modal/SourceCardModal.js
@@ -86,6 +86,22 @@ export const SourceCardModal = (props) => {
       {
         component: "text-field",
         label: intl.formatMessage({
+          defaultMessage: "ID",
+        }),
+        isRequired: true,
+        name: "id",
+        validate: [
+          {
+            type: validatorTypes.REQUIRED,
+          },
+          {
+            type: "custom",
+          },
+        ],
+      },
+      {
+        component: "text-field",
+        label: intl.formatMessage({
           defaultMessage: "Name",
         }),
         isRequired: true,
@@ -189,7 +205,7 @@ export const SourceCardModal = (props) => {
           <CardHeader className="pf-u-pr-0">
             <CardTitle>
               <Title headingLevel="h4" size="xl">
-                {props.source?.name}
+                {props.source?.id}
               </Title>
             </CardTitle>
             {props.isEditable && (
@@ -203,6 +219,12 @@ export const SourceCardModal = (props) => {
           <Divider />
           <CardBody>
             <DescriptionList isCompact isHorizontal>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Name</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {props.source?.name}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
               <DescriptionListGroup>
                 <DescriptionListTerm>Type</DescriptionListTerm>
                 <DescriptionListDescription>

--- a/src/components/Modal/SourceCardModal.js
+++ b/src/components/Modal/SourceCardModal.js
@@ -124,19 +124,19 @@ export const SourceCardModal = (props) => {
             label: intl.formatMessage({
               defaultMessage: "Yum repository",
             }),
-            value: "yum",
+            value: "yum-baseurl",
           },
           {
             label: intl.formatMessage({
               defaultMessage: "Mirrorlist",
             }),
-            value: "mirrorlist",
+            value: "yum-mirrorlist",
           },
           {
             label: intl.formatMessage({
               defaultMessage: "Metalink",
             }),
-            value: "metalink",
+            value: "yum-metalink",
           },
         ],
         validate: [

--- a/translations/en.json
+++ b/translations/en.json
@@ -194,6 +194,7 @@
   "q4qEK9": "OSBuild Composer is not started",
   "q5lNfF": "Alternatively, you may manually configure the file system of your image by adding, removing, and editing partitions.",
   "q96L4B": "DIUN Public Key Insecure",
+  "qlcuNQ": "ID",
   "r1lzNw": "Add ignition",
   "r6XTzy": "Stop image build",
   "rEQ/Rp": "Datastore",


### PR DESCRIPTION
[SourceCardModal: fix type values](https://github.com/osbuild/cockpit-composer/commit/a39a6518edf66a7cc742e4789c9b0e7db385a025) 

It's yum-baseurl, yum-mirrorlist and yum-metalink, see

https://github.com/osbuild/osbuild-composer/blob/95b4979d8876dc5ef5548d88633f47ead67e448f/internal/store/store.go#L640C2-L647C1

---

[SourceCardModal: switch to v1 weldr API](https://github.com/osbuild/cockpit-composer/commit/dae3063d83ca67b4f437b707dc5009a69f179c77) 

The v0 Weldr API actually doesn't support setting rhsm=true. Thus, we need to
switch to v1 in order to fix that. V1 requires IDs to be set on repos, so
I altered the modal to allow that.