### PR TITLE
Makefile: add metainfo to cockpit dir (RHEL-4660)

### DIFF
--- a/cockpit-composer.spec.in
+++ b/cockpit-composer.spec.in
@@ -32,8 +32,8 @@ the cloud. It integrates into Cockpit as a frontend for osbuild.
 mkdir -p %{buildroot}/%{_datadir}/cockpit/composer
 cp -a public/* %{buildroot}/%{_datadir}/cockpit/composer
 mkdir -p %{buildroot}/%{_datadir}/metainfo/
-appstream-util validate-relax --nonet public/io.weldr.cockpit-composer.metainfo.xml
-cp -a public/io.weldr.cockpit-composer.metainfo.xml %{buildroot}/%{_datadir}/metainfo/ 
+appstream-util validate-relax --nonet public/org.image-builder.cockpit-composer.metainfo.xml
+cp -a public/org.image-builder.cockpit-composer.metainfo.xml %{buildroot}/%{_datadir}/metainfo/ 
 
 %files
 %doc README.md

--- a/public/org.image-builder.cockpit-composer.metainfo.xml
+++ b/public/org.image-builder.cockpit-composer.metainfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="addon">
-  <id>io.weldr.cockpit_composer</id>
+  <id>org.image-builder.cockpit-composer</id>
   <metadata_license>CC0-1.0</metadata_license>
   <name>Image Builder</name>
   <summary>


### PR DESCRIPTION
In order to install cockpit-composer through cockpit the metainfo.xml should be copide into the cockpit/composer directory.