### PR TITLE
workflows: Switch release to cockpit/tasks container

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,14 +8,14 @@ jobs:
   source:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/cockpit-project/unit-tests
+      image: quay.io/cockpit/tasks:latest
       options: --user root
     permissions:
       # create GitHub release
       contents: write
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
The unit-tests container was dropped in
https://github.com/cockpit-project/cockpit/commit/f16f1fc14b88c

Cherry-picked from https://github.com/cockpit-project/starter-kit/commit/6e1427493a