### PR TITLE
test: bump to Fedora 40

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Extract the version from package.json
 VERSION=$(shell $(CURDIR)/rpmversion.sh | cut -d - -f 1)
 RELEASE=$(shell $(CURDIR)/rpmversion.sh | cut -d - -f 2)
-TEST_OS ?= fedora-37
+TEST_OS ?= fedora-40
 export TEST_OS
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)
 


### PR DESCRIPTION
A Fedora 37 machine was used for testing, Fedora 37 has been EOL for a while and is no longer available in cockpit-machines. Let's bump it to Fedora 40 which is currently branched but should go beta soon.