### PR TITLE
ci: Add PR best practices check

### DIFF
--- a/.github/workflows/pr_best_practices.yml
+++ b/.github/workflows/pr_best_practices.yml
@@ -1,0 +1,14 @@
+name: "Verify PR best practices"
+
+on:
+  pull_request_target:
+    branches: [ main ]
+
+jobs:
+  pr-best-practices:
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR best practice check
+        uses: osbuild/pr-best-practices@main
+        with:
+          token: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}


### PR DESCRIPTION
This PR adds the `best practices` check that we have in most of our other repositories already. Since it's part of our official pull request flow recommendation I guess it makes sense: https://osbuild.org/docs/developer-guide/general/workflow#pull-requests-