### PR TITLE
helpers: remove empty customization fields [COMPOSER-2204]

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -9,6 +9,23 @@ export const formTimestampLabel = (ts) => {
   return tsDisplay;
 };
 
+export const cleanEmptyFields = (obj) => {
+  const cleaned = Object.entries(obj).reduce((fields, [key, value]) => {
+    if (value === undefined || value === null || value === "") {
+      return fields;
+    }
+    if (typeof value === "object") {
+      const cleanedValue = cleanEmptyFields(value);
+      if (Object.keys(cleanedValue).length === 0) {
+        return fields;
+      }
+      return { ...fields, [key]: cleanedValue };
+    }
+    return { ...fields, [key]: value };
+  }, {});
+  return cleaned;
+};
+
 export const blueprintToFormState = (blueprint) => {
   if (!blueprint) return {};
   const formState = {
@@ -83,7 +100,7 @@ const formStateToCustomizations = (customizations) => {
   };
   const filesystem = customizations.filesystem
     ? customizations.filesystem.map(parseFilesystem)
-    : [];
+    : undefined;
 
   let openscap;
   if (
@@ -125,9 +142,11 @@ export const formStateToBlueprint = (formValues) => {
     ? formStateToCustomizations(formValues?.customizations)
     : undefined;
 
+  const cleanEmptyCustomizations = cleanEmptyFields(customizations);
+
   const blueprint = {
     ...formValues.blueprint,
-    customizations,
+    customizations: cleanEmptyCustomizations,
     packages,
   };
   return blueprint;

--- a/test/verify/check-imageWizard
+++ b/test/verify/check-imageWizard
@@ -52,6 +52,23 @@ class TestImageWizard(composerlib.ComposerCase):
         # Cancel upload
         b.click("footer button:contains('Cancel')")
 
+    @unittest.skipIf(os.environ.get("TEST_OS").split('-')[0] != "rhel", "Skipping test for non RHEL")
+    def testEdgeImageFields(self):
+        b = self.browser
+
+        self.login_and_go("/composer", superuser=True)
+        b.wait_visible("#main")
+
+        # Select create image from created blueprint
+        b.click("tr[data-testid=httpd-server] button[aria-label='Create image']")
+        b.wait_in_text(".pf-c-wizard__main", "httpd-server")
+        time.sleep(1)
+        # Edge image type
+        b.select_PF4("#image-output-select-toggle", "RHEL for Edge Simplified Installer (.iso)")
+        b.click("button:contains('Next')")
+
+        b.click("footer button:contains('Create')")
+
 
 if __name__ == '__main__':
     testlib.test_main()


### PR DESCRIPTION
Customizations that contain empty arrays or objects instead of being undefined cause failed image builds even with a valid blueprint.

The clean function recursively removes this empty fields from the blueprint object and fixes the edge image build failures.