### PR TITLE
createimagewizard: new edge types (RHEL-4689)

### DIFF
--- a/src/components/Wizard/CreateImageWizard.js
+++ b/src/components/Wizard/CreateImageWizard.js
@@ -93,7 +93,10 @@ const CreateImageWizard = (props) => {
 
     let uploadSettings;
     if (formValues?.image?.isUpload) {
-      if (formValues?.image?.type === "ami") {
+      if (
+        formValues?.image?.type === "ami" ||
+        formValues?.image.type === "edge-ami"
+      ) {
         uploadSettings = {
           image_name: formValues.image.upload.image_name,
           provider: "aws",
@@ -116,7 +119,8 @@ const CreateImageWizard = (props) => {
         };
       } else if (
         formValues?.image?.type === "vmdk" ||
-        formValues?.image?.type === "ova"
+        formValues?.image?.type === "ova" ||
+        formValues?.image?.type === "edge-vsphere"
       ) {
         uploadSettings = {
           image_name: formValues.image.upload.image_name,
@@ -173,6 +177,8 @@ const CreateImageWizard = (props) => {
       "edge-installer",
       "edge-raw-image",
       "edge-simplified-installer",
+      "edge-ami",
+      "edge-vsphere",
     ];
     if (ostreeImageTypes.includes(formValues?.image?.type)) {
       ostreeSettings = {

--- a/src/constants.js
+++ b/src/constants.js
@@ -19,9 +19,11 @@ export const ImageTypeLabels = {
   "edge-raw-image": "RHEL for Edge Raw Image (.raw.xz)",
   "image-installer": "RHEL Installer (.iso)",
   "edge-simplified-installer": "RHEL for Edge Simplified Installer (.iso)",
+  "edge-ami": "RHEL for Edge AMI (.raw)",
+  "edge-vsphere": "RHEL for Edge VMware vSphere (.vmdk)",
   vhd: "Microsoft Azure (.vhd)",
-  vmdk: "VMware VSphere (.vmdk)",
-  ova: "VMware VSphere (.ova)",
+  vmdk: "VMware vSphere (.vmdk)",
+  ova: "VMware vSphere (.ova)",
   gce: "Google Cloud Platform (.tar.gz)",
 };
 

--- a/src/forms/steps/awsDest.js
+++ b/src/forms/steps/awsDest.js
@@ -46,7 +46,12 @@ const awsDest = (intl) => {
     title: <FormattedMessage defaultMessage="Destination" />,
     name: "aws-dest",
     substepOf: intl.formatMessage(messages.awsStepsTitle),
-    nextStep: "review-image",
+    nextStep: ({ values }) => {
+      if (values.image?.type === "edge-ami") {
+        return "ostree-settings";
+      }
+      return "review-image";
+    },
     fields: [
       {
         component: "text-field-custom",

--- a/src/forms/steps/imageOutput.js
+++ b/src/forms/steps/imageOutput.js
@@ -177,7 +177,7 @@ const imageOutput = (intl) => {
         ),
         condition: {
           when: "image.type",
-          is: "ami",
+          is: ["ami", "edge-ami"],
         },
       },
       {
@@ -256,7 +256,7 @@ const imageOutput = (intl) => {
         ),
         condition: {
           when: "image.type",
-          is: ["vmdk", "ova"],
+          is: ["vmdk", "ova", "edge-vsphere"],
         },
       },
       {
@@ -351,6 +351,8 @@ const imageOutput = (intl) => {
             "edge-container",
             "edge-installer",
             "image-installer",
+            "edge-ami",
+            "edge-vsphere",
           ],
           notMatch: true,
         },
@@ -369,7 +371,7 @@ const imageOutput = (intl) => {
         ],
         resolveProps: (props, { meta, input }, formOptions) => {
           const imageType = formOptions.getState().values["image.type"];
-          if (imageType === "ami") {
+          if (imageType === "ami" || imageType === "edge-ami") {
             return {
               initialValue: 6,
               helperText: intl.formatMessage(messages.imageSizeInputHelp, {

--- a/src/forms/steps/imageOutputStepMapper.js
+++ b/src/forms/steps/imageOutputStepMapper.js
@@ -2,6 +2,7 @@ export default (props) => {
   if (props?.image?.isUpload) {
     switch (props?.image?.type) {
       case "ami":
+      case "edge-ami":
         return "aws-auth";
       case "oci":
         return "oci-auth";
@@ -9,6 +10,7 @@ export default (props) => {
         return "azure-auth";
       case "vmdk":
       case "ova":
+      case "edge-vsphere":
         return "vmware-auth";
       case "gce":
         return "gcp";
@@ -24,6 +26,8 @@ export default (props) => {
       "edge-installer",
       "edge-raw-image",
       "edge-simplified-installer",
+      "edge-ami",
+      "edge-vsphere",
     ].includes(props?.image?.type)
   ) {
     return "ostree-settings";

--- a/src/forms/steps/ostreeSettings.js
+++ b/src/forms/steps/ostreeSettings.js
@@ -84,6 +84,8 @@ const ostreeSettings = (intl) => {
             "edge-raw-image",
             "edge-installer",
             "edge-simplified-installer",
+            "edge-ami",
+            "edge-vsphere",
           ],
         },
         resolveProps: (props, { meta, input }, formOptions) => {
@@ -162,6 +164,8 @@ const ostreeSettings = (intl) => {
             "edge-installer",
             "edge-raw-image",
             "edge-simplified-installer",
+            "edge-ami",
+            "edge-vsphere",
           ],
         },
         validate: [

--- a/src/forms/steps/vmwareDest.js
+++ b/src/forms/steps/vmwareDest.js
@@ -70,7 +70,12 @@ const vmwareDest = (intl) => {
     title: <FormattedMessage defaultMessage="Destination" />,
     name: "vmware-dest",
     substepOf: intl.formatMessage(messages.vmwareStepsTitle),
-    nextStep: "review-image",
+    nextStep: ({ values }) => {
+      if (values.image?.type === "edge-vsphere") {
+        return "ostree-settings";
+      }
+      return "review-image";
+    },
     fields: [
       {
         component: "text-field-custom",


### PR DESCRIPTION
Add the `edge-ami` and `edge-vsphere` image types. These image types require both their respective upload settings as well as the `ostree-settings`.