### PR TITLE
packit: build RPMs in COPR for commits to `main`

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -15,8 +15,9 @@ srpm_build_deps:
 
 jobs:
   - job: copr_build
-    trigger: release
-    metadata:
+    trigger: commit
+    metadata: &build_metadata
+      branch: main
       owner: "@osbuild"
       project: "cockpit-composer"
       preserve_project: True
@@ -26,13 +27,18 @@ jobs:
       - epel-8
       - epel-9
       - fedora-all
-    actions:
+    actions: &build_actions
       post-upstream-clone: make spec
       # HACK: tarball for releases (copr_build, koji, etc.), copying spec's Source0; this
       # really should be the default, see https://github.com/packit/packit-service/issues/1505
       create-archive:
         - sh -exc "curl -L -O https://github.com/osbuild/cockpit-composer/releases/download/${PACKIT_PROJECT_VERSION}/${PACKIT_PROJECT_NAME_VERSION}.tar.gz"
         - sh -exc "ls ${PACKIT_PROJECT_NAME_VERSION}.tar.gz"
+
+  - job: copr_build
+    trigger: release
+    metadata: *build_metadata
+    actions: *build_actions
 
   - job: propose_downstream
     trigger: release


### PR DESCRIPTION
Make COPR rpm builds for any commits that land in main. This will allow us to test the project more easily.