### PR TITLE
ci: Drop dependabot integration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"
-      time: "04:00"
-    open-pull-requests-limit: 3
-    rebase-strategy: "auto"


### PR DESCRIPTION
Since the project is not maintained, it doesn't make sense to keep dependabot submitting PRs about dependency updates.